### PR TITLE
Fix complex staircase rendering with lowest points on other levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ useful for the project.
 
 ### Fixed
 
-- 
+- Fixed complex staircases not rendering when their feature contains lowest points on another level.
 
 ### Removed
 

--- a/src/components/staircase/staircaseRenderBuilder.ts
+++ b/src/components/staircase/staircaseRenderBuilder.ts
@@ -131,9 +131,6 @@ export function filterConnectedPathways(
     return [];
   }
 
-  const lowestNodes = featurePathCoordinates.filter((point) =>
-    lowestPoints.some((lowestPoint) => isFeatureAtPosition(lowestPoint, point))
-  );
   const lowestNodesOnCurrentLevel = featurePathCoordinates.filter((point) =>
     lowestPoints.some(
       (lowestPoint) =>
@@ -144,7 +141,7 @@ export function filterConnectedPathways(
   const doorNodes = featurePathCoordinates.filter((point) =>
     doors.some((door) => isSamePosition(door, point))
   );
-  const specialNodes = lowestNodes.length > 0
+  const specialNodes = lowestNodesOnCurrentLevel.length > 0
     ? lowestNodesOnCurrentLevel
     : doorNodes;
 


### PR DESCRIPTION
## Summary

This hotfix restores complex staircase rendering when a staircase feature contains lowest points that belong to another level.

The pathway filtering now only uses lowest points on the current level as special connection nodes. If no current-level lowest point exists, it falls back to door-connected pathway nodes as intended.

## Changes

- Fixed complex staircases disappearing when their feature contains lowest points on a different level.
- Added the hotfix entry to the changelog.