### PR TITLE
Search result suggestion cards with sorting, filtering, and ARIA support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,17 +14,20 @@ useful for the project.
 
 ### Added
 
-- 
+- Live search suggestion cards with category icons, room-type labels, and keyboard-accessible buttons/ARIA combobox pattern.
+- Clear buttons for search input and errors, plus a suggestion sort-order debug view.
+- Multi-key suggestion sorting (per-field match score, level, wheelchair accessibility, selection/infopoint proximity) via a reusable comparator-chain utility.
 
 ### Changed
 
-- 
+- Enter/Search now routes through the sorted suggestion list instead of the old `handleIndoorSearch`/`runIndoorSearch` path.
+- Search errors now surface inline above the search bar instead of as a top-left toast.
 
 ### Fixed
 
-- 
+- Suggestions now filter out features without a level, indoor-type features, waste baskets, and can filter out OSM name artifacts, e.g. ("yes"/"no").
 
-### Removed
+### Reworked
 
 - 
 

--- a/public/index.html
+++ b/public/index.html
@@ -35,16 +35,18 @@
     </aside>
 
     <!--           INDOOR ROOM SEARCH           -->
-    <div class="from-group row flex-nowrap" id="indoorSearchWrapper">
-        <ul id="searchSuggestionsList" aria-label="Search suggestions" role="listbox"></ul>
-        <div class="input-group" style="height:var(--button-size)">
-            <input class="form-control" type="text" placeholder="Search indoor"
-                   aria-label="Search indoor"
-                   id="indoorSearchInput" name="indoorSearchInput">
-            <button class="btn btn-secondary" id="indoorSearchSubmit"
-                    name="indoorSearchSubmit">
-                Search
-            </button>
+    <div id="indoorSearchWrapper">
+        <ul id="searchSuggestionsList" aria-label="Search suggestions"></ul>
+        <div class="from-group row flex-nowrap" id="indoorSearchBar">
+            <div class="input-group" style="height:var(--button-size)">
+                <input class="form-control" type="text" placeholder="Search indoor"
+                       aria-label="Search indoor"
+                       id="indoorSearchInput" name="indoorSearchInput">
+                <button class="btn btn-secondary" id="indoorSearchSubmit"
+                        name="indoorSearchSubmit">
+                    Search
+                </button>
+            </div>
         </div>
     </div>
 

--- a/public/index.html
+++ b/public/index.html
@@ -36,7 +36,6 @@
 
     <!--           INDOOR ROOM SEARCH           -->
     <div id="indoorSearchWrapper">
-        <ul id="searchSuggestionsList" aria-label="Search suggestions"></ul>
         <div class="from-group row flex-nowrap" id="indoorSearchBar">
             <div class="input-group" style="height:var(--button-size)">
                 <input class="form-control" type="text" placeholder="Search indoor"
@@ -48,6 +47,7 @@
                 </button>
             </div>
         </div>
+        <ul id="searchSuggestionsList" aria-label="Search suggestions"></ul>
     </div>
 
     <!--           LEVEL CONTROL           -->

--- a/public/index.html
+++ b/public/index.html
@@ -35,9 +35,9 @@
     </aside>
 
     <!--           INDOOR ROOM SEARCH           -->
-    <div class="from-group row flex-nowrap" id="indoorSearchWrapper" style="height:var(--button-size)">
-        <!-- <label class="d-flex flex-nowrap text-white align-items-center justify-content-lg-end col-4 justify-content-sm-start" for="indoorSearchInput" id="currentRoom">Current Room:</label> -->
-        <div class="input-group">
+    <div class="from-group row flex-nowrap" id="indoorSearchWrapper">
+        <ul id="searchSuggestionsList" aria-label="Search suggestions" role="listbox"></ul>
+        <div class="input-group" style="height:var(--button-size)">
             <input class="form-control" type="text" placeholder="Search indoor"
                    aria-label="Search indoor"
                    id="indoorSearchInput" name="indoorSearchInput">

--- a/public/index.html
+++ b/public/index.html
@@ -48,6 +48,7 @@
             </div>
         </div>
         <ul id="searchSuggestionsList" aria-label="Search suggestions"></ul>
+        <div id="searchErrorMessage" class="search-error-message" role="alert" aria-live="assertive"></div>
     </div>
 
     <!--           LEVEL CONTROL           -->

--- a/public/index.html
+++ b/public/index.html
@@ -41,6 +41,10 @@
                 <input class="form-control" type="text" placeholder="Search indoor"
                        aria-label="Search indoor"
                        id="indoorSearchInput" name="indoorSearchInput">
+                <button class="btn btn-outline-secondary search-clear-button" type="button"
+                        id="indoorSearchClear" name="indoorSearchClear">
+                    <span class="material-icons" aria-hidden="true">close</span>
+                </button>
                 <button class="btn btn-secondary" id="indoorSearchSubmit"
                         name="indoorSearchSubmit">
                     Search
@@ -48,7 +52,12 @@
             </div>
         </div>
         <ul id="searchSuggestionsList" aria-label="Search suggestions"></ul>
-        <div id="searchErrorMessage" class="search-error-message" role="alert" aria-live="assertive"></div>
+        <div id="searchErrorMessage" class="search-error-message" role="alert" aria-live="assertive">
+            <span id="searchErrorText"></span>
+            <button type="button" id="searchErrorClear" class="search-error-clear">
+                <span class="material-icons" aria-hidden="true">close</span>
+            </button>
+        </div>
     </div>
 
     <!--           LEVEL CONTROL           -->

--- a/public/index.html
+++ b/public/index.html
@@ -40,7 +40,12 @@
             <div class="input-group" style="height:var(--button-size)">
                 <input class="form-control" type="text" placeholder="Search indoor"
                        aria-label="Search indoor"
-                       id="indoorSearchInput" name="indoorSearchInput">
+                       id="indoorSearchInput" name="indoorSearchInput"
+                       role="combobox"
+                       aria-autocomplete="list"
+                       aria-expanded="false"
+                       aria-controls="searchSuggestionsList"
+                       aria-activedescendant="">
                 <button class="btn btn-outline-secondary search-clear-button" type="button"
                         id="indoorSearchClear" name="indoorSearchClear">
                     <span class="material-icons" aria-hidden="true">close</span>
@@ -51,7 +56,8 @@
                 </button>
             </div>
         </div>
-        <ul id="searchSuggestionsList" aria-label="Search suggestions"></ul>
+        <ul id="searchSuggestionsList" role="listbox" aria-label="Search suggestions"></ul>
+        <div id="searchAnnouncement" class="visually-hidden" aria-live="polite" aria-atomic="true"></div>
         <div id="searchErrorMessage" class="search-error-message" role="alert" aria-live="assertive">
             <span id="searchErrorText"></span>
             <button type="button" id="searchErrorClear" class="search-error-clear">

--- a/public/strings/constants.json
+++ b/public/strings/constants.json
@@ -30,6 +30,8 @@
         "ENTRANCE": "entrance.svg",
         "EMERGENCY_EXIT": "emergency_exit.svg",
         "STAIRS": "stairs.svg",
+        "CAFE": "restaurant.svg",
+        "SHOP": "shop.svg",
         "ADDITIONAL": "additional.svg"
     }
 }

--- a/public/strings/lang.de.json
+++ b/public/strings/lang.de.json
@@ -55,6 +55,7 @@
   "searchBuildingFound": "Gebäude gefunden.",
   "searchEmpty": "Bitte einen Suchbegriff eingeben!",
   "searchNotFound": "Nicht gefunden!",
+  "searchSuggestionLevel": "Etage ",
 
   "buildingNotFound": "Gebäude konnte nicht gefunden werden",
   "buildingNotSITconform": "Gebäude wurde gefunden, gehört jedoch nicht zum Datensatz von SIT-konformen Gebäuden",

--- a/public/strings/lang.de.json
+++ b/public/strings/lang.de.json
@@ -6,6 +6,8 @@
   "buildingSearchPlaceholder": "Nach Gebäuden suchen",
   "indoorSearchPlaceholder": "Im Gebäude suchen",
   "clearBuildingSearch": "Gebäudesuchfeld leeren",
+  "clearIndoorSearch": "Suchfeld leeren",
+  "clearSearchError": "Suchfehler schließen",
   "centeringButton": "Sicht zum fokussierten Gebäude zentrieren",
   "currentBuilding": "Ausgewähltes Gebäude",
   "currentRoom": "Ausgewählter Raum",

--- a/public/strings/lang.de.json
+++ b/public/strings/lang.de.json
@@ -58,6 +58,8 @@
   "searchEmpty": "Bitte einen Suchbegriff eingeben!",
   "searchNotFound": "Nicht gefunden!",
   "searchSuggestionLevel": "Etage ",
+  "searchSuggestionsAvailable": "{count} Suchvorschläge verfügbar.",
+  "searchSuggestionsNone": "Keine Suchvorschläge verfügbar.",
 
   "buildingNotFound": "Gebäude konnte nicht gefunden werden",
   "buildingNotSITconform": "Gebäude wurde gefunden, gehört jedoch nicht zum Datensatz von SIT-konformen Gebäuden",

--- a/public/strings/lang.en.json
+++ b/public/strings/lang.en.json
@@ -6,6 +6,8 @@
   "buildingSearchPlaceholder": "Search for buildings",
   "indoorSearchPlaceholder": "Search indoor",
   "clearBuildingSearch": "Clear search field",
+  "clearIndoorSearch": "Clear indoor search field",
+  "clearSearchError": "Dismiss search error",
   "centeringButton": "Set view to the focused building",
   "currentBuilding": "Current Building",
   "currentRoom": "Current Room",

--- a/public/strings/lang.en.json
+++ b/public/strings/lang.en.json
@@ -58,6 +58,8 @@
   "searchEmpty": "Please enter a search term!",
   "searchNotFound": "Not found!",
   "searchSuggestionLevel": "Level ",
+  "searchSuggestionsAvailable": "{count} search suggestions available.",
+  "searchSuggestionsNone": "No search suggestions available.",
 
   "buildingNotFound": "Building could not be found",
   "buildingNotSITconform": "Building was found, but is not in the dataset of SIT-conform buildings",

--- a/public/strings/lang.en.json
+++ b/public/strings/lang.en.json
@@ -55,6 +55,7 @@
   "searchBuildingFound": "Building found.",
   "searchEmpty": "Please enter a search term!",
   "searchNotFound": "Not found!",
+  "searchSuggestionLevel": "Level ",
 
   "buildingNotFound": "Building could not be found",
   "buildingNotSITconform": "Building was found, but is not in the dataset of SIT-conform buildings",

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -179,8 +179,18 @@ nav {
     #searchSuggestionsList {
       display: none;
       list-style: none;
-      margin: 0 0 6px 0;
+      margin: 0;
       padding: 0;
+      // Absolutely positioned (relative to #indoorSearchWrapper, which is
+      // position:absolute) so it renders above the search bar regardless of
+      // DOM order. DOM order is input-then-list so Tab flows input -> search
+      // button -> suggestion cards; using flex `order` instead would risk
+      // decoupling visual position from focus order across browsers.
+      position: absolute;
+      left: 0;
+      right: 0;
+      bottom: 100%;
+      margin-bottom: 6px;
 
       &.visible {
         display: flex;
@@ -191,6 +201,14 @@ nav {
       }
 
       .search-suggestion-card {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 8px;
+        width: 100%;
+        font: inherit;
+        text-align: left;
+        color: inherit;
         background: #fffffff0;
         border: 1px solid var(--button-border-color);
         border-radius: var(--button-border-radius);
@@ -198,8 +216,15 @@ nav {
         cursor: pointer;
         box-shadow: 0 2px 4px rgba(0, 0, 0, 0.12);
 
-        &:hover {
+        &:hover,
+        &:focus-visible {
           background: var(--button-hover-bg);
+        }
+
+        .suggestion-text {
+          display: flex;
+          flex-direction: column;
+          min-width: 0;
         }
 
         .suggestion-name {

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -229,7 +229,7 @@ nav {
         font: inherit;
         text-align: left;
         color: inherit;
-        background: #fffffff0;
+        background: #fffffff8;
         border: 1px solid var(--button-border-color);
         border-radius: var(--button-border-radius);
         padding: 8px 12px;

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -247,6 +247,29 @@ nav {
         }
       }
     }
+
+    #searchErrorMessage {
+      display: none;
+      // Same slot as #searchSuggestionsList (above the bar). Mutually
+      // exclusive with it by construction: submitSearch() clears suggestions
+      // before showing an error, and the input listener clears any error
+      // before showing suggestions again.
+      position: absolute;
+      left: 0;
+      right: 0;
+      bottom: 100%;
+      margin-bottom: 6px;
+      padding: 8px 12px;
+      border-radius: var(--button-border-radius);
+      background: var(--bs-danger-bg-subtle, #f8d7da);
+      color: var(--bs-danger-text-emphasis, #842029);
+      border: 1px solid var(--bs-danger-border-subtle, #f5c2c7);
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.12);
+
+      &.visible {
+        display: block;
+      }
+    }
   }
 
 

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -239,6 +239,12 @@ nav {
           color: #666;
           margin-top: 2px;
         }
+
+        .suggestion-icon {
+          flex: 0 0 auto;
+          width: 32px;
+          height: 32px;
+        }
       }
     }
   }

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -237,7 +237,9 @@ nav {
         box-shadow: 0 2px 4px rgba(0, 0, 0, 0.12);
 
         &:hover,
-        &:focus-visible {
+        &:focus-visible,
+        &.active,
+        &[aria-selected="true"] {
           background: var(--button-hover-bg);
         }
 

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -166,12 +166,55 @@ nav {
     -moz-transform: translate(-50%, 0);
     -ms-transform: translate(-50%, 0);
     -o-transform: translate(-50%, 0);
+    display: flex;
+    flex-direction: column;
 
     #indoorSearchSubmit {
       color: var(--button-active-color);
       background-color: var(--button-active-bg);
       text-decoration: none;
       border: var(--button-border-width) solid var(--button-active-border-color);
+    }
+
+    #searchSuggestionsList {
+      display: none;
+      list-style: none;
+      margin: 0 0 6px 0;
+      padding: 0;
+
+      &.visible {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        max-height: 300px;
+        overflow-y: auto;
+      }
+
+      .search-suggestion-card {
+        background: #fffffff0;
+        border: 1px solid var(--button-border-color);
+        border-radius: var(--button-border-radius);
+        padding: 8px 12px;
+        cursor: pointer;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.12);
+
+        &:hover {
+          background: var(--button-hover-bg);
+        }
+
+        .suggestion-name {
+          display: block;
+          font-weight: 600;
+          color: var(--button-color);
+        }
+
+        .suggestion-levels {
+          display: block;
+          font-size: 0.8em;
+          color: #666;
+          margin-top: 2px;
+        }
+      }
     }
   }
 

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -176,6 +176,26 @@ nav {
       border: var(--button-border-width) solid var(--button-active-border-color);
     }
 
+    #indoorSearchClear {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: var(--button-size);
+      color: var(--button-color);
+      background-color: var(--button-bg);
+      border-color: var(--button-border-color);
+
+      .material-icons {
+        font-size: 20px;
+      }
+    }
+
+    #indoorSearchClear:hover {
+      background-color: var(--button-hover-bg);
+      border-color: var(--button-hover-border-color);
+      color: var(--button-hover-color);
+    }
+
     #searchSuggestionsList {
       display: none;
       list-style: none;
@@ -265,9 +285,39 @@ nav {
       color: var(--bs-danger-text-emphasis, #842029);
       border: 1px solid var(--bs-danger-border-subtle, #f5c2c7);
       box-shadow: 0 2px 4px rgba(0, 0, 0, 0.12);
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+
+      #searchErrorText {
+        min-width: 0;
+      }
+
+      .search-error-clear {
+        display: inline-flex;
+        flex: 0 0 auto;
+        align-items: center;
+        justify-content: center;
+        width: 28px;
+        height: 28px;
+        padding: 0;
+        color: currentColor;
+        background: transparent;
+        border: 0;
+        border-radius: var(--button-border-radius);
+
+        &:hover,
+        &:focus-visible {
+          background: rgba(0, 0, 0, 0.08);
+        }
+
+        .material-icons {
+          font-size: 18px;
+        }
+      }
 
       &.visible {
-        display: block;
+        display: flex;
       }
     }
   }

--- a/src/components/geoMap.ts
+++ b/src/components/geoMap.ts
@@ -21,10 +21,11 @@ import BackendService, { type BuildingCenter } from "../services/backendService"
 import { MapCamera } from "./map/mapCamera";
 import { MapBounds, MapCenterConstraint, MapView } from "./map/mapView";
 import { MapLibreMapView } from "./map/maplibreMapView";
-import { getRequiredFeatureId, getRequiredFeatureProperties } from "../utils/geoJsonHelpers";
+import { getRequiredFeatureId } from "../utils/geoJsonHelpers";
 import { getRequiredArrayValue, getRequiredMapValue } from "../utils/requiredHelpers";
 import { getRequiredElement } from "../utils/domHelpers";
 import CoordinateHelpers from "../utils/coordinateHelpers";
+import { getFeatureLevels } from "../utils/featureLevels";
 
 export class GeoMap {
   private readonly mapView: MapView;
@@ -43,7 +44,7 @@ export class GeoMap {
   standardBearing3DMode = 0;
   infoPoint: GeoJSON.Feature;
   infoPointLevel = INDOOR_LEVEL;
-  configMode = false; // set only during configuration of building constants
+  configMode = true; // set only during configuration of building constants
   private isLevelTransitionRunning = false;
 
   constructor() {
@@ -348,7 +349,7 @@ export class GeoMap {
         // from the levels of the feature, select the nearest to the current level
         const result = getRequiredArrayValue(results, 0, "Indoor search results");
         const selectedLevel = getRequiredArrayValue(
-          (getRequiredFeatureProperties(result).level as number[])
+          getFeatureLevels(result)
             .sort((a, b) => Math.abs(a - this.currentLevel) - Math.abs(b - this.currentLevel)),
           0,
           "Indoor search result levels"
@@ -368,7 +369,7 @@ export class GeoMap {
     this.selectedFeatures = [getRequiredFeatureId(feature)];
     this.indoorLayers.forEach((layer) => layer.updateLayer());
 
-    const levels = getRequiredFeatureProperties(feature).level as number[];
+    const levels = getFeatureLevels(feature);
     if (levels && levels.length > 0) {
       const selectedLevel = [...levels].sort(
         (a, b) => Math.abs(a - this.currentLevel) - Math.abs(b - this.currentLevel)

--- a/src/components/geoMap.ts
+++ b/src/components/geoMap.ts
@@ -10,7 +10,6 @@ import {
 import LevelControl from "./ui/levelControl";
 import DescriptionArea from "./ui/descriptionArea";
 import BuildingService from "../services/buildingService";
-import LoadingIndicator from "./ui/loadingIndicator";
 import { IndoorLevel } from "./indoorLevel";
 import AccessibilityService from "../services/accessibilityService";
 import LevelService from "../services/levelService";
@@ -337,32 +336,6 @@ export class GeoMap {
     // TODO: might need to optimize this, needs a long time to update all layers at the moment
     // idea: only update the layers that are needed
     this.indoorLayers.forEach((layer) => layer.updateLayer());
-  }
-
-  handleIndoorSearch(searchString: string): void {
-    if (searchString) {
-      const results = BuildingService.runIndoorSearch(searchString);
-      if (results.length != 0) {
-        this.selectedFeatures = results.map((feature) => getRequiredFeatureId(feature));
-        this.indoorLayers.forEach((layer) => layer.updateLayer());
-
-        // from the levels of the feature, select the nearest to the current level
-        const result = getRequiredArrayValue(results, 0, "Indoor search results");
-        const selectedLevel = getRequiredArrayValue(
-          getFeatureLevels(result)
-            .sort((a, b) => Math.abs(a - this.currentLevel) - Math.abs(b - this.currentLevel)),
-          0,
-          "Indoor search result levels"
-        );
-        if (this.handleLevelChange(selectedLevel)) {
-          LevelControl.focusOnLevel(selectedLevel);
-        }
-
-        const accessibilityDescription =
-          FeatureService.getAccessibilityDescription(result);
-        DescriptionArea.update(accessibilityDescription);
-      } else LoadingIndicator.error(lang.searchNotFound);
-    } else LoadingIndicator.error(lang.searchEmpty);
   }
 
   selectIndoorFeature(feature: GeoJSON.Feature): void {

--- a/src/components/geoMap.ts
+++ b/src/components/geoMap.ts
@@ -43,7 +43,7 @@ export class GeoMap {
   standardBearing3DMode = 0;
   infoPoint: GeoJSON.Feature;
   infoPointLevel = INDOOR_LEVEL;
-  configMode = true; // set only during configuration of building constants
+  configMode = false; // set only during configuration of building constants
   private isLevelTransitionRunning = false;
 
   constructor() {

--- a/src/components/geoMap.ts
+++ b/src/components/geoMap.ts
@@ -364,6 +364,24 @@ export class GeoMap {
     } else LoadingIndicator.error(lang.searchEmpty);
   }
 
+  selectIndoorFeature(feature: GeoJSON.Feature): void {
+    this.selectedFeatures = [getRequiredFeatureId(feature)];
+    this.indoorLayers.forEach((layer) => layer.updateLayer());
+
+    const levels = getRequiredFeatureProperties(feature).level as number[];
+    if (levels && levels.length > 0) {
+      const selectedLevel = [...levels].sort(
+        (a, b) => Math.abs(a - this.currentLevel) - Math.abs(b - this.currentLevel)
+      )[0];
+      if (this.handleLevelChange(selectedLevel)) {
+        LevelControl.focusOnLevel(selectedLevel);
+      }
+    }
+
+    const accessibilityDescription = FeatureService.getAccessibilityDescription(feature);
+    DescriptionArea.update(accessibilityDescription);
+  }
+
   applyStyleFilters = (): void => {
     this.mapView.setBaseLayerOpacity(ColorService.getEnvOpacity() / 100);
     this.mapView.setSaturation((ColorService.getColorStrength() * 2) / 100);

--- a/src/components/ui/centeringButton.ts
+++ b/src/components/ui/centeringButton.ts
@@ -9,8 +9,8 @@ function create(geoMap: GeoMap): void {
   button.onclick = () => geoMap.centerMapToBuilding();
   button.innerHTML = '<span aria-label="' + lang.centeringButton + '" title="' + lang.centeringButton + '"><i class="material-icons">center_focus_weak</i></span>';
 
-  const indoorSearch = getRequiredElement("indoorSearchWrapper");
-  indoorSearch.insertBefore(button, indoorSearch.firstChild);
+  const indoorSearchBar = getRequiredElement("indoorSearchBar");
+  indoorSearchBar.insertBefore(button, indoorSearchBar.firstChild);
 }
 
 export default {

--- a/src/components/ui/centeringButton.ts
+++ b/src/components/ui/centeringButton.ts
@@ -2,7 +2,9 @@ import type { GeoMap } from "../geoMap";
 import { lang } from "../../services/languageService";
 import { getRequiredElement } from "../../utils/domHelpers";
 
-function create(geoMap: GeoMap): void {
+function create(
+  geoMap: GeoMap
+): void {
   const button = document.createElement("button");
   button.className = "square";
   button.id = "centeringButton";

--- a/src/components/ui/searchForm.ts
+++ b/src/components/ui/searchForm.ts
@@ -18,7 +18,12 @@ function render(geoMap: GeoMap): void {
   indoorSearchInput.addEventListener("input", () => {
     const query = indoorSearchInput.value;
     if (query.length >= 1) {
-      SearchSuggestions.update(BuildingService.searchSuggestions(query));
+      SearchSuggestions.update(BuildingService.searchSuggestions(query, {
+        currentLevel: geoMap.currentLevel,
+        infoPointFeature: geoMap.infoPoint.geometry.type !== "GeometryCollection"
+          ? geoMap.infoPoint
+          : undefined,
+      }));
     } else {
       SearchSuggestions.clear();
     }

--- a/src/components/ui/searchForm.ts
+++ b/src/components/ui/searchForm.ts
@@ -18,8 +18,13 @@ function render(geoMap: GeoMap): void {
   indoorSearchInput.addEventListener("input", () => {
     const query = indoorSearchInput.value;
     if (query.length >= 1) {
+      const selectedId = geoMap.selectedFeatures[0];
+      const selectedFeature = selectedId
+        ? BuildingService.getBuildingGeoJSON().features.find((f) => f.id?.toString() === selectedId)
+        : undefined;
       SearchSuggestions.update(BuildingService.searchSuggestions(query, {
         currentLevel: geoMap.currentLevel,
+        selectedFeature,
         infoPointFeature: geoMap.infoPoint.geometry.type !== "GeometryCollection"
           ? geoMap.infoPoint
           : undefined,

--- a/src/components/ui/searchForm.ts
+++ b/src/components/ui/searchForm.ts
@@ -71,7 +71,7 @@ function render(geoMap: GeoMap): void {
     geoMap.selectIndoorFeature(suggestion.feature);
   };
 
-  SearchSuggestions.render(selectSuggestion);
+  SearchSuggestions.render(indoorSearchInput, selectSuggestion);
 
   indoorSearchInput.addEventListener("input", () => {
     clearSearchError();
@@ -95,7 +95,7 @@ function render(geoMap: GeoMap): void {
     clearSearchError();
   });
 
-  indoorSearchInput.addEventListener("keyup", (e) => {
+  indoorSearchInput.addEventListener("keydown", (e) => {
     if (e.key === "Enter") {
       e.preventDefault();
       submitSearch(geoMap, selectSuggestion);

--- a/src/components/ui/searchForm.ts
+++ b/src/components/ui/searchForm.ts
@@ -1,51 +1,75 @@
 import type { GeoMap } from "../geoMap";
 import { lang } from "../../services/languageService";
 import { getRequiredElement } from "../../utils/domHelpers";
-import BuildingService from "../../services/buildingService";
+import BuildingService, { type SearchSuggestion, type SuggestionSortContext } from "../../services/buildingService";
 import SearchSuggestions from "./searchSuggestions";
+import LoadingIndicator from "./loadingIndicator";
+import UserService from "../../services/userService";
+import { UserGroupEnum } from "../../models/userGroupEnum";
 
 const indoorSearchSubmit = getRequiredElement<HTMLButtonElement>("indoorSearchSubmit");
 const indoorSearchInput = getRequiredElement<HTMLInputElement>("indoorSearchInput");
 
-const state: { indoorSearchQuery: string } = { indoorSearchQuery: "" };
+function buildSortContext(geoMap: GeoMap): SuggestionSortContext {
+  const selectedId = geoMap.selectedFeatures[0];
+  const selectedFeature = selectedId
+    ? BuildingService.getBuildingGeoJSON().features.find((f) => f.id?.toString() === selectedId)
+    : undefined;
+
+  return {
+    currentLevel: geoMap.currentLevel,
+    selectedFeature,
+    infoPointFeature: geoMap.infoPoint.geometry.type !== "GeometryCollection"
+      ? geoMap.infoPoint
+      : undefined,
+    wheelchairMode: UserService.getCurrentProfile() === UserGroupEnum.wheelchairUsers,
+  };
+}
+
+function submitSearch(geoMap: GeoMap, selectSuggestion: (suggestion: SearchSuggestion) => void): void {
+  const query = indoorSearchInput.value;
+  if (!query) {
+    LoadingIndicator.error(lang.searchEmpty);
+    return;
+  }
+
+  const results = BuildingService.searchSuggestions(query, buildSortContext(geoMap));
+  SearchSuggestions.clear();
+
+  const best = results[0];
+  if (!best) {
+    LoadingIndicator.error(lang.searchNotFound);
+    return;
+  }
+
+  selectSuggestion(best);
+}
 
 function render(geoMap: GeoMap): void {
-  SearchSuggestions.render((suggestion) => {
+  const selectSuggestion = (suggestion: SearchSuggestion): void => {
     indoorSearchInput.value = suggestion.displayName;
     geoMap.selectIndoorFeature(suggestion.feature);
-  });
+  };
+
+  SearchSuggestions.render(selectSuggestion);
 
   indoorSearchInput.addEventListener("input", () => {
     const query = indoorSearchInput.value;
     if (query.length >= 1) {
-      const selectedId = geoMap.selectedFeatures[0];
-      const selectedFeature = selectedId
-        ? BuildingService.getBuildingGeoJSON().features.find((f) => f.id?.toString() === selectedId)
-        : undefined;
-      SearchSuggestions.update(BuildingService.searchSuggestions(query, {
-        currentLevel: geoMap.currentLevel,
-        selectedFeature,
-        infoPointFeature: geoMap.infoPoint.geometry.type !== "GeometryCollection"
-          ? geoMap.infoPoint
-          : undefined,
-      }));
+      SearchSuggestions.update(BuildingService.searchSuggestions(query, buildSortContext(geoMap)));
     } else {
       SearchSuggestions.clear();
     }
   });
 
   indoorSearchSubmit.addEventListener("click", () => {
-    SearchSuggestions.clear();
-    state.indoorSearchQuery = indoorSearchInput.value;
-    geoMap.handleIndoorSearch(indoorSearchInput.value);
+    submitSearch(geoMap, selectSuggestion);
   });
 
   indoorSearchInput.addEventListener("keyup", (e) => {
     if (e.key === "Enter") {
       e.preventDefault();
-      SearchSuggestions.clear();
-      state.indoorSearchQuery = indoorSearchInput.value;
-      geoMap.handleIndoorSearch(indoorSearchInput.value);
+      submitSearch(geoMap, selectSuggestion);
     }
   });
 

--- a/src/components/ui/searchForm.ts
+++ b/src/components/ui/searchForm.ts
@@ -1,6 +1,8 @@
 import type { GeoMap } from "../geoMap";
 import { lang } from "../../services/languageService";
 import { getRequiredElement } from "../../utils/domHelpers";
+import BuildingService from "../../services/buildingService";
+import SearchSuggestions from "./searchSuggestions";
 
 const indoorSearchSubmit = getRequiredElement<HTMLButtonElement>("indoorSearchSubmit");
 const indoorSearchInput = getRequiredElement<HTMLInputElement>("indoorSearchInput");
@@ -8,18 +10,31 @@ const indoorSearchInput = getRequiredElement<HTMLInputElement>("indoorSearchInpu
 const state: { indoorSearchQuery: string } = { indoorSearchQuery: "" };
 
 function render(geoMap: GeoMap): void {
-  indoorSearchSubmit.addEventListener("click", () => {
-    state.indoorSearchQuery = indoorSearchInput.value;
+  SearchSuggestions.render((suggestion) => {
+    indoorSearchInput.value = suggestion.displayName;
+    geoMap.selectIndoorFeature(suggestion.feature);
+  });
 
+  indoorSearchInput.addEventListener("input", () => {
+    const query = indoorSearchInput.value;
+    if (query.length >= 1) {
+      SearchSuggestions.update(BuildingService.searchSuggestions(query));
+    } else {
+      SearchSuggestions.clear();
+    }
+  });
+
+  indoorSearchSubmit.addEventListener("click", () => {
+    SearchSuggestions.clear();
+    state.indoorSearchQuery = indoorSearchInput.value;
     geoMap.handleIndoorSearch(indoorSearchInput.value);
   });
 
   indoorSearchInput.addEventListener("keyup", (e) => {
     if (e.key === "Enter") {
       e.preventDefault();
-
+      SearchSuggestions.clear();
       state.indoorSearchQuery = indoorSearchInput.value;
-
       geoMap.handleIndoorSearch(indoorSearchInput.value);
     }
   });

--- a/src/components/ui/searchForm.ts
+++ b/src/components/ui/searchForm.ts
@@ -8,16 +8,25 @@ import { UserGroupEnum } from "../../models/userGroupEnum";
 
 const indoorSearchSubmit = getRequiredElement<HTMLButtonElement>("indoorSearchSubmit");
 const indoorSearchInput = getRequiredElement<HTMLInputElement>("indoorSearchInput");
+const indoorSearchClear = getRequiredElement<HTMLButtonElement>("indoorSearchClear");
 const searchErrorMessage = getRequiredElement<HTMLDivElement>("searchErrorMessage");
+const searchErrorText = getRequiredElement<HTMLSpanElement>("searchErrorText");
+const searchErrorClear = getRequiredElement<HTMLButtonElement>("searchErrorClear");
 
 function showSearchError(message: string): void {
-  searchErrorMessage.textContent = message;
+  searchErrorText.textContent = message;
   searchErrorMessage.classList.add("visible");
 }
 
 function clearSearchError(): void {
-  searchErrorMessage.textContent = "";
+  searchErrorText.textContent = "";
   searchErrorMessage.classList.remove("visible");
+}
+
+function clearSearchInput(): void {
+  indoorSearchInput.value = "";
+  SearchSuggestions.clear();
+  clearSearchError();
 }
 
 function buildSortContext(geoMap: GeoMap): SuggestionSortContext {
@@ -38,7 +47,7 @@ function buildSortContext(geoMap: GeoMap): SuggestionSortContext {
 
 function submitSearch(geoMap: GeoMap, selectSuggestion: (suggestion: SearchSuggestion) => void): void {
   clearSearchError();
-  const query = indoorSearchInput.value;
+  const query = indoorSearchInput.value.trim();
   if (!query) {
     showSearchError(lang.searchEmpty);
     return;
@@ -66,7 +75,7 @@ function render(geoMap: GeoMap): void {
 
   indoorSearchInput.addEventListener("input", () => {
     clearSearchError();
-    const query = indoorSearchInput.value;
+    const query = indoorSearchInput.value.trim();
     if (query.length >= 1) {
       SearchSuggestions.update(BuildingService.searchSuggestions(query, buildSortContext(geoMap)));
     } else {
@@ -76,6 +85,14 @@ function render(geoMap: GeoMap): void {
 
   indoorSearchSubmit.addEventListener("click", () => {
     submitSearch(geoMap, selectSuggestion);
+  });
+
+  indoorSearchClear.addEventListener("click", () => {
+    clearSearchInput();
+  });
+
+  searchErrorClear.addEventListener("click", () => {
+    clearSearchError();
   });
 
   indoorSearchInput.addEventListener("keyup", (e) => {
@@ -92,6 +109,10 @@ function updateLabels(): void {
   indoorSearchSubmit.innerText = lang.indoorSearchSubmit;
   indoorSearchInput.setAttribute("placeholder", lang.indoorSearchPlaceholder);
   indoorSearchInput.setAttribute("aria-label", lang.indoorSearchPlaceholder);
+  indoorSearchClear.setAttribute("aria-label", lang.clearIndoorSearch);
+  indoorSearchClear.setAttribute("title", lang.clearIndoorSearch);
+  searchErrorClear.setAttribute("aria-label", lang.clearSearchError);
+  searchErrorClear.setAttribute("title", lang.clearSearchError);
 }
 
 export default {

--- a/src/components/ui/searchForm.ts
+++ b/src/components/ui/searchForm.ts
@@ -3,12 +3,22 @@ import { lang } from "../../services/languageService";
 import { getRequiredElement } from "../../utils/domHelpers";
 import BuildingService, { type SearchSuggestion, type SuggestionSortContext } from "../../services/buildingService";
 import SearchSuggestions from "./searchSuggestions";
-import LoadingIndicator from "./loadingIndicator";
 import UserService from "../../services/userService";
 import { UserGroupEnum } from "../../models/userGroupEnum";
 
 const indoorSearchSubmit = getRequiredElement<HTMLButtonElement>("indoorSearchSubmit");
 const indoorSearchInput = getRequiredElement<HTMLInputElement>("indoorSearchInput");
+const searchErrorMessage = getRequiredElement<HTMLDivElement>("searchErrorMessage");
+
+function showSearchError(message: string): void {
+  searchErrorMessage.textContent = message;
+  searchErrorMessage.classList.add("visible");
+}
+
+function clearSearchError(): void {
+  searchErrorMessage.textContent = "";
+  searchErrorMessage.classList.remove("visible");
+}
 
 function buildSortContext(geoMap: GeoMap): SuggestionSortContext {
   const selectedId = geoMap.selectedFeatures[0];
@@ -27,9 +37,10 @@ function buildSortContext(geoMap: GeoMap): SuggestionSortContext {
 }
 
 function submitSearch(geoMap: GeoMap, selectSuggestion: (suggestion: SearchSuggestion) => void): void {
+  clearSearchError();
   const query = indoorSearchInput.value;
   if (!query) {
-    LoadingIndicator.error(lang.searchEmpty);
+    showSearchError(lang.searchEmpty);
     return;
   }
 
@@ -38,7 +49,7 @@ function submitSearch(geoMap: GeoMap, selectSuggestion: (suggestion: SearchSugge
 
   const best = results[0];
   if (!best) {
-    LoadingIndicator.error(lang.searchNotFound);
+    showSearchError(lang.searchNotFound);
     return;
   }
 
@@ -54,6 +65,7 @@ function render(geoMap: GeoMap): void {
   SearchSuggestions.render(selectSuggestion);
 
   indoorSearchInput.addEventListener("input", () => {
+    clearSearchError();
     const query = indoorSearchInput.value;
     if (query.length >= 1) {
       SearchSuggestions.update(BuildingService.searchSuggestions(query, buildSortContext(geoMap)));

--- a/src/components/ui/searchSuggestions.ts
+++ b/src/components/ui/searchSuggestions.ts
@@ -59,12 +59,15 @@ function update(suggestions: SearchSuggestion[]): void {
     textWrapper.appendChild(levelsSpan);
     button.appendChild(textWrapper);
 
-    const icon = document.createElement("img");
-    icon.className = "suggestion-icon";
-    icon.src = getCategoryIcon(suggestion.feature);
-    icon.alt = "";
-    icon.setAttribute("aria-hidden", "true");
-    button.appendChild(icon);
+    const categoryIcon = getCategoryIcon(suggestion.feature);
+    if (categoryIcon) {
+      const icon = document.createElement("img");
+      icon.className = "suggestion-icon";
+      icon.src = categoryIcon;
+      icon.alt = "";
+      icon.setAttribute("aria-hidden", "true");
+      button.appendChild(icon);
+    }
 
     const li = document.createElement("li");
     li.appendChild(button);

--- a/src/components/ui/searchSuggestions.ts
+++ b/src/components/ui/searchSuggestions.ts
@@ -1,6 +1,7 @@
 import type { SearchSuggestion } from "../../services/buildingService";
 import { lang } from "../../services/languageService";
 import { getRequiredElement } from "../../utils/domHelpers";
+import { getCategoryIcon } from "../../services/featureService";
 
 const suggestionsList = getRequiredElement<HTMLUListElement>("searchSuggestionsList");
 
@@ -57,6 +58,13 @@ function update(suggestions: SearchSuggestion[]): void {
     textWrapper.appendChild(nameSpan);
     textWrapper.appendChild(levelsSpan);
     button.appendChild(textWrapper);
+
+    const icon = document.createElement("img");
+    icon.className = "suggestion-icon";
+    icon.src = getCategoryIcon(suggestion.feature);
+    icon.alt = "";
+    icon.setAttribute("aria-hidden", "true");
+    button.appendChild(icon);
 
     const li = document.createElement("li");
     li.appendChild(button);

--- a/src/components/ui/searchSuggestions.ts
+++ b/src/components/ui/searchSuggestions.ts
@@ -33,7 +33,6 @@ function update(suggestions: SearchSuggestion[]): void {
     const li = document.createElement("li");
     li.className = "search-suggestion-card";
     li.setAttribute("data-suggestion-index", index.toString());
-    li.setAttribute("role", "option");
 
     const nameSpan = document.createElement("span");
     nameSpan.className = "suggestion-name";
@@ -41,9 +40,8 @@ function update(suggestions: SearchSuggestion[]): void {
 
     const levelsSpan = document.createElement("span");
     levelsSpan.className = "suggestion-levels";
-    levelsSpan.textContent = suggestion.levels
-      .map((l) => lang.searchSuggestionLevel + l)
-      .join(", ");
+    const levelText = suggestion.levels.map((l) => lang.searchSuggestionLevel + l).join(", ");
+    levelsSpan.textContent = suggestion.type ? `${levelText} · ${suggestion.type}` : levelText;
 
     li.appendChild(nameSpan);
     li.appendChild(levelsSpan);

--- a/src/components/ui/searchSuggestions.ts
+++ b/src/components/ui/searchSuggestions.ts
@@ -8,16 +8,21 @@ let currentSuggestions: SearchSuggestion[] = [];
 
 function render(onSelect: (suggestion: SearchSuggestion) => void): void {
   suggestionsList.addEventListener("click", (e) => {
-    const li = (e.target as HTMLElement).closest<HTMLElement>("li[data-suggestion-index]");
-    if (!li) return;
+    const button = (e.target as HTMLElement).closest<HTMLButtonElement>("button[data-suggestion-index]");
+    if (!button) return;
 
-    const index = parseInt(li.dataset.suggestionIndex ?? "-1", 10);
+    const index = parseInt(button.dataset.suggestionIndex ?? "-1", 10);
     const suggestion = currentSuggestions[index];
     if (suggestion) {
       onSelect(suggestion);
       clear();
     }
   });
+}
+
+function buildSubtitle(suggestion: SearchSuggestion): string {
+  const levelText = suggestion.levels.map((l) => lang.searchSuggestionLevel + l).join(", ");
+  return suggestion.type ? `${levelText} · ${suggestion.type}` : levelText;
 }
 
 function update(suggestions: SearchSuggestion[]): void {
@@ -30,9 +35,16 @@ function update(suggestions: SearchSuggestion[]): void {
   }
 
   suggestions.forEach((suggestion, index) => {
-    const li = document.createElement("li");
-    li.className = "search-suggestion-card";
-    li.setAttribute("data-suggestion-index", index.toString());
+    const subtitle = buildSubtitle(suggestion);
+
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "search-suggestion-card";
+    button.setAttribute("data-suggestion-index", index.toString());
+    button.setAttribute("aria-label", `${suggestion.displayName}, ${subtitle}`);
+
+    const textWrapper = document.createElement("span");
+    textWrapper.className = "suggestion-text";
 
     const nameSpan = document.createElement("span");
     nameSpan.className = "suggestion-name";
@@ -40,11 +52,14 @@ function update(suggestions: SearchSuggestion[]): void {
 
     const levelsSpan = document.createElement("span");
     levelsSpan.className = "suggestion-levels";
-    const levelText = suggestion.levels.map((l) => lang.searchSuggestionLevel + l).join(", ");
-    levelsSpan.textContent = suggestion.type ? `${levelText} · ${suggestion.type}` : levelText;
+    levelsSpan.textContent = subtitle;
 
-    li.appendChild(nameSpan);
-    li.appendChild(levelsSpan);
+    textWrapper.appendChild(nameSpan);
+    textWrapper.appendChild(levelsSpan);
+    button.appendChild(textWrapper);
+
+    const li = document.createElement("li");
+    li.appendChild(button);
     suggestionsList.appendChild(li);
   });
 

--- a/src/components/ui/searchSuggestions.ts
+++ b/src/components/ui/searchSuggestions.ts
@@ -1,0 +1,62 @@
+import type { SearchSuggestion } from "../../services/buildingService";
+import { lang } from "../../services/languageService";
+import { getRequiredElement } from "../../utils/domHelpers";
+
+const suggestionsList = getRequiredElement<HTMLUListElement>("searchSuggestionsList");
+
+let currentSuggestions: SearchSuggestion[] = [];
+
+function render(onSelect: (suggestion: SearchSuggestion) => void): void {
+  suggestionsList.addEventListener("click", (e) => {
+    const li = (e.target as HTMLElement).closest<HTMLElement>("li[data-suggestion-index]");
+    if (!li) return;
+
+    const index = parseInt(li.dataset.suggestionIndex ?? "-1", 10);
+    const suggestion = currentSuggestions[index];
+    if (suggestion) {
+      onSelect(suggestion);
+      clear();
+    }
+  });
+}
+
+function update(suggestions: SearchSuggestion[]): void {
+  currentSuggestions = suggestions;
+  suggestionsList.innerHTML = "";
+
+  if (suggestions.length === 0) {
+    suggestionsList.classList.remove("visible");
+    return;
+  }
+
+  suggestions.forEach((suggestion, index) => {
+    const li = document.createElement("li");
+    li.className = "search-suggestion-card";
+    li.setAttribute("data-suggestion-index", index.toString());
+    li.setAttribute("role", "option");
+
+    const nameSpan = document.createElement("span");
+    nameSpan.className = "suggestion-name";
+    nameSpan.textContent = suggestion.displayName;
+
+    const levelsSpan = document.createElement("span");
+    levelsSpan.className = "suggestion-levels";
+    levelsSpan.textContent = suggestion.levels
+      .map((l) => lang.searchSuggestionLevel + l)
+      .join(", ");
+
+    li.appendChild(nameSpan);
+    li.appendChild(levelsSpan);
+    suggestionsList.appendChild(li);
+  });
+
+  suggestionsList.classList.add("visible");
+}
+
+function clear(): void {
+  currentSuggestions = [];
+  suggestionsList.innerHTML = "";
+  suggestionsList.classList.remove("visible");
+}
+
+export default { render, update, clear };

--- a/src/components/ui/searchSuggestions.ts
+++ b/src/components/ui/searchSuggestions.ts
@@ -4,19 +4,41 @@ import { getRequiredElement } from "../../utils/domHelpers";
 import { getCategoryIcon } from "../../services/featureService";
 
 const suggestionsList = getRequiredElement<HTMLUListElement>("searchSuggestionsList");
+const searchAnnouncement = getRequiredElement<HTMLDivElement>("searchAnnouncement");
+const ANNOUNCEMENT_DELAY_MS = 250;
 
 let currentSuggestions: SearchSuggestion[] = [];
+let activeIndex = -1;
+let isPopupOpen = false;
+let inputElement: HTMLInputElement | undefined;
+let announcementTimer: ReturnType<typeof setTimeout> | undefined;
 
-function render(onSelect: (suggestion: SearchSuggestion) => void): void {
+function render(
+  input: HTMLInputElement,
+  onSelect: (suggestion: SearchSuggestion) => void
+): void {
+  inputElement = input;
+  syncInputState();
+
+  suggestionsList.addEventListener("mousedown", (e) => {
+    e.preventDefault();
+  });
+
   suggestionsList.addEventListener("click", (e) => {
-    const button = (e.target as HTMLElement).closest<HTMLButtonElement>("button[data-suggestion-index]");
-    if (!button) return;
+    const option = (e.target as HTMLElement).closest<HTMLElement>("li[data-suggestion-index]");
+    if (!option) return;
 
-    const index = parseInt(button.dataset.suggestionIndex ?? "-1", 10);
+    const index = parseInt(option.dataset.suggestionIndex ?? "-1", 10);
     const suggestion = currentSuggestions[index];
     if (suggestion) {
       onSelect(suggestion);
       clear();
+    }
+  });
+
+  input.addEventListener("keydown", (e) => {
+    if (handleKeyDown(e, onSelect)) {
+      e.stopImmediatePropagation();
     }
   });
 }
@@ -26,23 +48,99 @@ function buildSubtitle(suggestion: SearchSuggestion): string {
   return suggestion.type ? `${levelText} · ${suggestion.type}` : levelText;
 }
 
+function handleKeyDown(
+  e: KeyboardEvent,
+  onSelect: (suggestion: SearchSuggestion) => void
+): boolean {
+  if (currentSuggestions.length === 0) {
+    return false;
+  }
+
+  if (e.key === "ArrowDown") {
+    e.preventDefault();
+    if (!isPopupOpen) {
+      open();
+      setActiveIndex(0);
+      return true;
+    }
+
+    setActiveIndex(activeIndex === -1 || activeIndex >= currentSuggestions.length - 1
+      ? 0
+      : activeIndex + 1);
+    return true;
+  }
+
+  if (e.key === "ArrowUp") {
+    e.preventDefault();
+    if (!isPopupOpen) {
+      open();
+      setActiveIndex(0);
+      return true;
+    }
+
+    setActiveIndex(activeIndex === -1
+      ? 0
+      : activeIndex > 0
+        ? activeIndex - 1
+        : currentSuggestions.length - 1);
+    return true;
+  }
+
+  if (e.key === "Home" && isPopupOpen && activeIndex !== -1) {
+    e.preventDefault();
+    setActiveIndex(0);
+    return true;
+  }
+
+  if (e.key === "End" && isPopupOpen && activeIndex !== -1) {
+    e.preventDefault();
+    setActiveIndex(currentSuggestions.length - 1);
+    return true;
+  }
+
+  if (e.key === "Enter" && isPopupOpen && activeIndex !== -1) {
+    e.preventDefault();
+    const suggestion = currentSuggestions[activeIndex];
+    if (suggestion) {
+      onSelect(suggestion);
+      clear();
+    }
+    return true;
+  }
+
+  if (e.key === "Escape" && isPopupOpen) {
+    e.preventDefault();
+    hide();
+    return true;
+  }
+
+  return false;
+}
+
 function update(suggestions: SearchSuggestion[]): void {
   currentSuggestions = suggestions;
+  activeIndex = -1;
+  isPopupOpen = suggestions.length > 0;
   suggestionsList.innerHTML = "";
+  syncInputState();
 
   if (suggestions.length === 0) {
     suggestionsList.classList.remove("visible");
+    announceSuggestionCount(0);
     return;
   }
 
   suggestions.forEach((suggestion, index) => {
     const subtitle = buildSubtitle(suggestion);
 
-    const button = document.createElement("button");
-    button.type = "button";
-    button.className = "search-suggestion-card";
-    button.setAttribute("data-suggestion-index", index.toString());
-    button.setAttribute("aria-label", `${suggestion.displayName}, ${subtitle}`);
+    const option = document.createElement("li");
+    option.id = `search-suggestion-${index}`;
+    option.setAttribute("role", "option");
+    option.className = "search-suggestion-card";
+    option.tabIndex = -1;
+    option.setAttribute("data-suggestion-index", index.toString());
+    option.setAttribute("aria-selected", "false");
+    option.setAttribute("aria-label", `${suggestion.displayName}, ${subtitle}`);
 
     const textWrapper = document.createElement("span");
     textWrapper.className = "suggestion-text";
@@ -57,7 +155,7 @@ function update(suggestions: SearchSuggestion[]): void {
 
     textWrapper.appendChild(nameSpan);
     textWrapper.appendChild(levelsSpan);
-    button.appendChild(textWrapper);
+    option.appendChild(textWrapper);
 
     const categoryIcon = getCategoryIcon(suggestion.feature);
     if (categoryIcon) {
@@ -66,21 +164,82 @@ function update(suggestions: SearchSuggestion[]): void {
       icon.src = categoryIcon;
       icon.alt = "";
       icon.setAttribute("aria-hidden", "true");
-      button.appendChild(icon);
+      option.appendChild(icon);
     }
 
-    const li = document.createElement("li");
-    li.appendChild(button);
-    suggestionsList.appendChild(li);
+    suggestionsList.appendChild(option);
   });
 
   suggestionsList.classList.add("visible");
+  syncInputState();
+  announceSuggestionCount(suggestions.length);
 }
 
 function clear(): void {
   currentSuggestions = [];
+  activeIndex = -1;
+  isPopupOpen = false;
   suggestionsList.innerHTML = "";
   suggestionsList.classList.remove("visible");
+  clearAnnouncement();
+  syncInputState();
+}
+
+function open(): void {
+  if (currentSuggestions.length === 0) return;
+
+  isPopupOpen = true;
+  suggestionsList.classList.add("visible");
+  syncInputState();
+}
+
+function hide(): void {
+  isPopupOpen = false;
+  suggestionsList.classList.remove("visible");
+  setActiveIndex(-1);
+  clearAnnouncement();
+}
+
+function setActiveIndex(index: number): void {
+  activeIndex = index;
+  Array.from(suggestionsList.querySelectorAll<HTMLElement>("[role='option']")).forEach((option, optionIndex) => {
+    const isActive = optionIndex === activeIndex;
+    option.setAttribute("aria-selected", isActive.toString());
+    option.classList.toggle("active", isActive);
+    if (isActive && typeof option.scrollIntoView === "function") {
+      option.scrollIntoView({ block: "nearest" });
+    }
+  });
+  syncInputState();
+}
+
+function syncInputState(): void {
+  if (!inputElement) return;
+
+  inputElement.setAttribute("aria-expanded", isPopupOpen.toString());
+  inputElement.setAttribute(
+    "aria-activedescendant",
+    isPopupOpen && activeIndex >= 0 ? `search-suggestion-${activeIndex}` : ""
+  );
+}
+
+function announceSuggestionCount(count: number): void {
+  if (announcementTimer) {
+    clearTimeout(announcementTimer);
+  }
+  announcementTimer = setTimeout(() => {
+    searchAnnouncement.textContent = count === 0
+      ? lang.searchSuggestionsNone
+      : lang.searchSuggestionsAvailable.replace("{count}", count.toString());
+  }, ANNOUNCEMENT_DELAY_MS);
+}
+
+function clearAnnouncement(): void {
+  if (announcementTimer) {
+    clearTimeout(announcementTimer);
+    announcementTimer = undefined;
+  }
+  searchAnnouncement.textContent = "";
 }
 
 export default { render, update, clear };

--- a/src/services/buildingService.ts
+++ b/src/services/buildingService.ts
@@ -22,6 +22,11 @@ export interface SearchSuggestion {
   feature: GeoJSON.Feature;
 }
 
+export interface SuggestionSortContext {
+  currentLevel: number;
+  infoPointFeature?: GeoJSON.Feature;
+}
+
 /**
  * Finding a building by search string:
  * 1) Iterate through all building Features if there is a Feature with the given name. If so, return the building Feature.
@@ -156,10 +161,42 @@ function filterForSuggestions(f: GeoJSON.Feature, searchString: string): boolean
   );
 }
 
-function searchSuggestions(searchString: string): SearchSuggestion[] {
+function getFeatureCentroid(feature: GeoJSON.Feature): [number, number] | undefined {
+  const geom = feature.geometry;
+  if (geom.type === "Polygon" && geom.coordinates[0]?.length > 0) {
+    const ring = geom.coordinates[0];
+    return [
+      ring.reduce((s, c) => s + c[0], 0) / ring.length,
+      ring.reduce((s, c) => s + c[1], 0) / ring.length,
+    ];
+  }
+  if (geom.type === "LineString" && geom.coordinates.length > 0) {
+    const pts = geom.coordinates;
+    return [
+      pts.reduce((s, c) => s + c[0], 0) / pts.length,
+      pts.reduce((s, c) => s + c[1], 0) / pts.length,
+    ];
+  }
+  return undefined;
+}
+
+function matchScore(displayName: string, query: string): number {
+  const name = displayName.toLowerCase();
+  const q = query.toLowerCase();
+  if (name === q) return 0;
+  if (name.startsWith(q)) return 1;
+  if (name.includes(q)) return 2;
+  return 3;
+}
+
+function minLevelDistance(levels: number[], currentLevel: number): number {
+  return Math.min(...levels.map((l) => Math.abs(l - currentLevel)));
+}
+
+function searchSuggestions(searchString: string, context: SuggestionSortContext): SearchSuggestion[] {
   if (!searchString) return [];
   const geoJSON = getBuildingGeoJSON();
-  return geoJSON.features
+  const suggestions = geoJSON.features
     .filter((f) => filterForSuggestions(f, searchString))
     .map((f) => {
       const p = getRequiredFeatureProperties(f);
@@ -171,6 +208,27 @@ function searchSuggestions(searchString: string): SearchSuggestion[] {
         feature: f,
       };
     });
+
+  const infoCoords = context.infoPointFeature
+    ? getFeatureCentroid(context.infoPointFeature)
+    : undefined;
+
+  return suggestions.sort((a, b) => {
+    const matchDiff = matchScore(a.displayName, searchString) - matchScore(b.displayName, searchString);
+    if (matchDiff !== 0) return matchDiff;
+
+    if (infoCoords) {
+      const ca = getFeatureCentroid(a.feature);
+      const cb = getFeatureCentroid(b.feature);
+      if (ca && cb) {
+        const dx = (ca[0] - infoCoords[0]) ** 2 + (ca[1] - infoCoords[1]) ** 2;
+        const dy = (cb[0] - infoCoords[0]) ** 2 + (cb[1] - infoCoords[1]) ** 2;
+        if (dx !== dy) return dx - dy;
+      }
+    }
+
+    return minLevelDistance(a.levels, context.currentLevel) - minLevelDistance(b.levels, context.currentLevel);
+  });
 }
 
 // /*Filter*/

--- a/src/services/buildingService.ts
+++ b/src/services/buildingService.ts
@@ -29,6 +29,7 @@ export interface SuggestionSortContext {
   currentLevel: number;
   selectedFeature?: GeoJSON.Feature;
   infoPointFeature?: GeoJSON.Feature;
+  wheelchairMode?: boolean;
 }
 
 /**
@@ -248,6 +249,11 @@ function minLevelDistance(
   return Math.min(...levels.map((l) => Math.abs(l - currentLevel)));
 }
 
+function isWheelchairAccessible(feature: GeoJSON.Feature): boolean {
+  const wheelchair = getRequiredFeatureProperties(feature).wheelchair;
+  return wheelchair !== undefined && ["yes", "designated"].includes(wheelchair);
+}
+
 function searchSuggestions(
   searchString: string,
   context: SuggestionSortContext
@@ -291,6 +297,11 @@ function searchSuggestions(
     getRequiredMapValue(scores, a.id, "Search suggestion score") -
     getRequiredMapValue(scores, b.id, "Search suggestion score");
 
+  const byWheelchairAccessibility = (a: SearchSuggestion, b: SearchSuggestion): number => {
+    if (!context.wheelchairMode) return 0;
+    return Number(isWheelchairAccessible(b.feature)) - Number(isWheelchairAccessible(a.feature));
+  };
+
   const byLevelDistance = (a: SearchSuggestion, b: SearchSuggestion): number =>
     minLevelDistance(a.levels, context.currentLevel) - minLevelDistance(b.levels, context.currentLevel);
 
@@ -306,6 +317,7 @@ function searchSuggestions(
   // Priority order, most important first. Reorder this list to change ranking behavior.
   return suggestions.sort(chainComparators(
     byMatchScore,
+    byWheelchairAccessibility,
     byLevelDistance,
     byProximityTo(selectedCoords),
     byProximityTo(infoCoords)

--- a/src/services/buildingService.ts
+++ b/src/services/buildingService.ts
@@ -135,11 +135,19 @@ function filterByString(f: GeoJSON.Feature, searchString: string) {
   );
 }
 
+const OSM_NAME_ARTIFACTS = new Set(["yes", "no"]);
+
+function getValidName(p: Record<string, unknown>): string | undefined {
+  const name = p.name;
+  if (typeof name !== "string" || OSM_NAME_ARTIFACTS.has(name.toLowerCase())) return undefined;
+  return name;
+}
+
 function filterForSuggestions(f: GeoJSON.Feature, searchString: string): boolean {
   const p = getRequiredFeatureProperties(f);
   const s = searchString.toLowerCase();
   return !!(
-    p.name?.toLowerCase().includes(s) ||
+    getValidName(p)?.toLowerCase().includes(s) ||
     p.ref?.toLowerCase().startsWith(s) ||
     p.amenity?.toLowerCase().startsWith(s)
   );
@@ -154,7 +162,7 @@ function searchSuggestions(searchString: string): SearchSuggestion[] {
       const p = getRequiredFeatureProperties(f);
       return {
         id: getRequiredFeatureId(f),
-        displayName: (p.name ?? p.ref ?? p.indoor ?? p.amenity ?? "?") as string,
+        displayName: (getValidName(p) ?? p.ref ?? p.indoor ?? p.amenity ?? "?") as string,
         levels: Array.isArray(p.level) ? (p.level as number[]) : [],
         type: (p.amenity ?? p.indoor) as string | undefined,
         feature: f,

--- a/src/services/buildingService.ts
+++ b/src/services/buildingService.ts
@@ -146,7 +146,7 @@ function getValidName(p: Record<string, unknown>): string | undefined {
 
 function filterForSuggestions(f: GeoJSON.Feature, searchString: string): boolean {
   const p = getRequiredFeatureProperties(f);
-  if (p.level == null) return false;
+  if (!Array.isArray(p.level) || p.level.length === 0) return false;
   if (p.amenity && EXCLUDED_AMENITIES.has(String(p.amenity))) return false;
   const s = searchString.toLowerCase();
   return !!(

--- a/src/services/buildingService.ts
+++ b/src/services/buildingService.ts
@@ -126,6 +126,7 @@ function nominatimSearch(searchString: string): Promise<BuildingInterface> {
 
 const OSM_NAME_ARTIFACTS = new Set([]);
 const EXCLUDED_AMENITIES = new Set(["waste_basket"]);
+const SEARCH_SUGGESTIONS_DEBUG_KEY = "debugSearchSuggestions";
 
 function getValidName(
   p: Record<string, unknown>
@@ -228,6 +229,14 @@ function isWheelchairAccessible(feature: GeoJSON.Feature): boolean {
   return wheelchair !== undefined && ["yes", "designated"].includes(wheelchair);
 }
 
+function isSearchSuggestionsDebugEnabled(): boolean {
+  try {
+    return globalThis.localStorage?.getItem(SEARCH_SUGGESTIONS_DEBUG_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
 function searchSuggestions(
   searchString: string,
   context: SuggestionSortContext
@@ -267,6 +276,15 @@ function searchSuggestions(
   const squaredDist = (a: [number, number], b: [number, number]): number =>
     (a[0] - b[0]) ** 2 + (a[1] - b[1]) ** 2;
 
+  const distanceTo = (
+    suggestion: SearchSuggestion,
+    coords: [number, number] | undefined
+  ): number | undefined => {
+    if (!coords) return undefined;
+    const centroid = centroids.get(suggestion.id);
+    return centroid ? squaredDist(centroid, coords) : undefined;
+  };
+
   const byMatchScore = (a: SearchSuggestion, b: SearchSuggestion): number =>
     getRequiredMapValue(scores, a.id, "Search suggestion score") -
     getRequiredMapValue(scores, b.id, "Search suggestion score");
@@ -282,20 +300,90 @@ function searchSuggestions(
   const byProximityTo = (coords: [number, number] | undefined) =>
     (a: SearchSuggestion, b: SearchSuggestion): number => {
       if (!coords) return 0;
-      const ca = centroids.get(a.id);
-      const cb = centroids.get(b.id);
-      if (!ca || !cb) return 0;
-      return squaredDist(ca, coords) - squaredDist(cb, coords);
+      const da = distanceTo(a, coords);
+      const db = distanceTo(b, coords);
+      if (da === undefined || db === undefined) return 0;
+      return da - db;
     };
 
   // Priority order, most important first. Reorder this list to change ranking behavior.
-  return suggestions.sort(chainComparators(
+  const sortedSuggestions = suggestions.sort(chainComparators(
     byMatchScore,
     byWheelchairAccessibility,
     byLevelDistance,
     byProximityTo(selectedCoords),
     byProximityTo(infoCoords)
   ));
+
+  // debug view for suggestion rankings
+  // activate using: localStorage.setItem("debugSearchSuggestions", "true")
+  // deactivate using: localStorage.removeItem("debugSearchSuggestions")
+  logSearchSuggestionRanking(searchString, sortedSuggestions, {
+    context,
+    scores,
+    centroids,
+    selectedCoords,
+    infoCoords,
+    distanceTo,
+  });
+
+  return sortedSuggestions;
+}
+
+function logSearchSuggestionRanking(
+  searchString: string,
+  suggestions: SearchSuggestion[],
+  debugContext: {
+    context: SuggestionSortContext;
+    scores: Map<string, number>;
+    centroids: Map<string, [number, number] | undefined>;
+    selectedCoords: [number, number] | undefined;
+    infoCoords: [number, number] | undefined;
+    distanceTo: (
+      suggestion: SearchSuggestion,
+      coords: [number, number] | undefined
+    ) => number | undefined;
+  }
+): void {
+  if (!isSearchSuggestionsDebugEnabled()) return;
+
+  const rows = suggestions.map((suggestion, index) => {
+    const centroid = debugContext.centroids.get(suggestion.id);
+    const wheelchairAccessible = isWheelchairAccessible(suggestion.feature);
+    return {
+      rank: index + 1,
+      id: suggestion.id,
+      displayName: suggestion.displayName,
+      type: suggestion.type ?? "",
+      levels: suggestion.levels.join(", "),
+      matchScore: getRequiredMapValue(debugContext.scores, suggestion.id, "Search suggestion score"),
+      wheelchairScore: debugContext.context.wheelchairMode
+        ? wheelchairAccessible ? 0 : 1
+        : 0,
+      wheelchairAccessible,
+      levelDistance: minLevelDistance(suggestion.levels, debugContext.context.currentLevel),
+      selectedDistanceSq: debugContext.distanceTo(suggestion, debugContext.selectedCoords) ?? "",
+      infoDistanceSq: debugContext.distanceTo(suggestion, debugContext.infoCoords) ?? "",
+      centroid: centroid ? centroid.join(", ") : "",
+    };
+  });
+
+  console.debug("[SearchSuggestions] ranking context", {
+    query: searchString,
+    currentLevel: debugContext.context.currentLevel,
+    wheelchairMode: debugContext.context.wheelchairMode === true,
+    selectedCoords: debugContext.selectedCoords,
+    infoCoords: debugContext.infoCoords,
+    sortOrder: [
+      "matchScore",
+      "wheelchairScore",
+      "levelDistance",
+      "selectedDistanceSq",
+      "infoDistanceSq",
+    ],
+    note: "Lower scores sort first. Proximity values are squared distances.",
+  });
+  console.table(rows);
 }
 
 // /*Filter*/

--- a/src/services/buildingService.ts
+++ b/src/services/buildingService.ts
@@ -169,6 +169,9 @@ function getFeatureCentroid(
       pts.reduce((s, c) => s + c[1], 0) / pts.length,
     ];
   }
+  if (geom.type === "Point") {
+    return [geom.coordinates[0], geom.coordinates[1]];
+  }
   return undefined;
 }
 

--- a/src/services/buildingService.ts
+++ b/src/services/buildingService.ts
@@ -140,7 +140,6 @@ function filterForSuggestions(f: GeoJSON.Feature, searchString: string): boolean
   return !!(
     p.name?.toLowerCase().includes(s) ||
     p.ref?.toLowerCase().startsWith(s) ||
-    p.indoor?.toLowerCase().startsWith(s) ||
     p.amenity?.toLowerCase().startsWith(s)
   );
 }

--- a/src/services/buildingService.ts
+++ b/src/services/buildingService.ts
@@ -13,6 +13,7 @@ import { extent} from "geojson-bounds";
 import { booleanContainsPoint } from "bbox-fns";
 import BackendService from "./backendService";
 import { getRequiredFeatureId, getRequiredFeatureProperties } from "../utils/geoJsonHelpers";
+import { getFeatureLevels } from "../utils/featureLevels";
 
 export interface SearchSuggestion {
   id: string;
@@ -162,13 +163,13 @@ function filterForSuggestions(
   searchString: string
 ): boolean {
   const p = getRequiredFeatureProperties(f);
-  if (!Array.isArray(p.level) || p.level.length === 0) return false;
+  if (getFeatureLevels(f).length === 0) return false;
   if (p.amenity && EXCLUDED_AMENITIES.has(String(p.amenity))) return false;
   const s = searchString.toLowerCase();
   return !!(
     getValidName(p)?.toLowerCase().includes(s) ||
-    p.ref?.toLowerCase().startsWith(s) ||
-    p.amenity?.toLowerCase().startsWith(s)
+    p.ref?.toLowerCase().includes(s) ||
+    p.amenity?.toLowerCase().includes(s)
   );
 }
 
@@ -225,7 +226,7 @@ function searchSuggestions(
       return {
         id: getRequiredFeatureId(f),
         displayName: (getValidName(p) ?? p.ref ?? p.indoor ?? p.amenity ?? "?") as string,
-        levels: Array.isArray(p.level) ? (p.level as number[]) : [],
+        levels: getFeatureLevels(f),
         type: (p.amenity ?? p.indoor) as string | undefined,
         feature: f,
       };

--- a/src/services/buildingService.ts
+++ b/src/services/buildingService.ts
@@ -24,6 +24,7 @@ export interface SearchSuggestion {
 
 export interface SuggestionSortContext {
   currentLevel: number;
+  selectedFeature?: GeoJSON.Feature;
   infoPointFeature?: GeoJSON.Feature;
 }
 
@@ -230,25 +231,45 @@ function searchSuggestions(
       };
     });
 
+  const centroids = new Map<string, [number, number] | undefined>(
+    suggestions.map((s) => [s.id, getFeatureCentroid(s.feature)])
+  );
+  const selectedCoords = context.selectedFeature
+    ? getFeatureCentroid(context.selectedFeature)
+    : undefined;
   const infoCoords = context.infoPointFeature
     ? getFeatureCentroid(context.infoPointFeature)
     : undefined;
+
+  const squaredDist = (a: [number, number], b: [number, number]): number =>
+    (a[0] - b[0]) ** 2 + (a[1] - b[1]) ** 2;
 
   return suggestions.sort((a, b) => {
     const matchDiff = matchScore(a.displayName, searchString) - matchScore(b.displayName, searchString);
     if (matchDiff !== 0) return matchDiff;
 
-    if (infoCoords) {
-      const ca = getFeatureCentroid(a.feature);
-      const cb = getFeatureCentroid(b.feature);
+    const levelDiff = minLevelDistance(a.levels, context.currentLevel) - minLevelDistance(b.levels, context.currentLevel);
+    if (levelDiff !== 0) return levelDiff;
+
+    if (selectedCoords) {
+      const ca = centroids.get(a.id);
+      const cb = centroids.get(b.id);
       if (ca && cb) {
-        const dx = (ca[0] - infoCoords[0]) ** 2 + (ca[1] - infoCoords[1]) ** 2;
-        const dy = (cb[0] - infoCoords[0]) ** 2 + (cb[1] - infoCoords[1]) ** 2;
-        if (dx !== dy) return dx - dy;
+        const diff = squaredDist(ca, selectedCoords) - squaredDist(cb, selectedCoords);
+        if (diff !== 0) return diff;
       }
     }
 
-    return minLevelDistance(a.levels, context.currentLevel) - minLevelDistance(b.levels, context.currentLevel);
+    if (infoCoords) {
+      const ca = centroids.get(a.id);
+      const cb = centroids.get(b.id);
+      if (ca && cb) {
+        const diff = squaredDist(ca, infoCoords) - squaredDist(cb, infoCoords);
+        if (diff !== 0) return diff;
+      }
+    }
+
+    return 0;
   });
 }
 

--- a/src/services/buildingService.ts
+++ b/src/services/buildingService.ts
@@ -124,32 +124,6 @@ function nominatimSearch(searchString: string): Promise<BuildingInterface> {
   });
 }
 
-function runIndoorSearch(
-  searchString: string
-): GeoJSON.Feature[] {
-  const geoJSON = getBuildingGeoJSON();
-
-  const results = geoJSON.features.filter((f) =>
-    filterByString(f, searchString)
-  );
-
-  return results;
-}
-
-function filterByString(
-  f: GeoJSON.Feature,
-  searchString: string
-) {
-  const properties = getRequiredFeatureProperties(f);
-  const s = searchString.toLowerCase();
-
-  return (
-    (properties.ref?.toLowerCase().startsWith(s)) || //room number
-    (properties.indoor?.toLowerCase().startsWith(s)) || //type
-    (properties.amenity?.toLowerCase().startsWith(s)) //toilet type
-  );
-}
-
 const OSM_NAME_ARTIFACTS = new Set([]);
 const EXCLUDED_AMENITIES = new Set(["waste_basket"]);
 
@@ -429,7 +403,6 @@ export default {
   getBuildingGeoJSON,
   getBuildingDescription,
   handleSearch,
-  runIndoorSearch,
   searchSuggestions,
   filterByBounds,
   filterInsideAndLevel

--- a/src/services/buildingService.ts
+++ b/src/services/buildingService.ts
@@ -146,6 +146,7 @@ function getValidName(p: Record<string, unknown>): string | undefined {
 
 function filterForSuggestions(f: GeoJSON.Feature, searchString: string): boolean {
   const p = getRequiredFeatureProperties(f);
+  if (p.level == null) return false;
   if (p.amenity && EXCLUDED_AMENITIES.has(String(p.amenity))) return false;
   const s = searchString.toLowerCase();
   return !!(

--- a/src/services/buildingService.ts
+++ b/src/services/buildingService.ts
@@ -119,7 +119,9 @@ function nominatimSearch(searchString: string): Promise<BuildingInterface> {
   });
 }
 
-function runIndoorSearch(searchString: string): GeoJSON.Feature[] {
+function runIndoorSearch(
+  searchString: string
+): GeoJSON.Feature[] {
   const geoJSON = getBuildingGeoJSON();
 
   const results = geoJSON.features.filter((f) =>
@@ -129,7 +131,10 @@ function runIndoorSearch(searchString: string): GeoJSON.Feature[] {
   return results;
 }
 
-function filterByString(f: GeoJSON.Feature, searchString: string) {
+function filterByString(
+  f: GeoJSON.Feature,
+  searchString: string
+) {
   const properties = getRequiredFeatureProperties(f);
   const s = searchString.toLowerCase();
 
@@ -143,13 +148,18 @@ function filterByString(f: GeoJSON.Feature, searchString: string) {
 const OSM_NAME_ARTIFACTS = new Set([]);
 const EXCLUDED_AMENITIES = new Set(["waste_basket"]);
 
-function getValidName(p: Record<string, unknown>): string | undefined {
+function getValidName(
+  p: Record<string, unknown>
+): string | undefined {
   const name = p.name;
   if (typeof name !== "string" || OSM_NAME_ARTIFACTS.has(name.toLowerCase())) return undefined;
   return name;
 }
 
-function filterForSuggestions(f: GeoJSON.Feature, searchString: string): boolean {
+function filterForSuggestions(
+  f: GeoJSON.Feature,
+  searchString: string
+): boolean {
   const p = getRequiredFeatureProperties(f);
   if (!Array.isArray(p.level) || p.level.length === 0) return false;
   if (p.amenity && EXCLUDED_AMENITIES.has(String(p.amenity))) return false;
@@ -161,7 +171,9 @@ function filterForSuggestions(f: GeoJSON.Feature, searchString: string): boolean
   );
 }
 
-function getFeatureCentroid(feature: GeoJSON.Feature): [number, number] | undefined {
+function getFeatureCentroid(
+  feature: GeoJSON.Feature
+): [number, number] | undefined {
   const geom = feature.geometry;
   if (geom.type === "Polygon" && geom.coordinates[0]?.length > 0) {
     const ring = geom.coordinates[0];
@@ -180,7 +192,10 @@ function getFeatureCentroid(feature: GeoJSON.Feature): [number, number] | undefi
   return undefined;
 }
 
-function matchScore(displayName: string, query: string): number {
+function matchScore(
+  displayName: string,
+  query: string
+): number {
   const name = displayName.toLowerCase();
   const q = query.toLowerCase();
   if (name === q) return 0;
@@ -189,11 +204,17 @@ function matchScore(displayName: string, query: string): number {
   return 3;
 }
 
-function minLevelDistance(levels: number[], currentLevel: number): number {
+function minLevelDistance(
+  levels: number[],
+  currentLevel: number
+): number {
   return Math.min(...levels.map((l) => Math.abs(l - currentLevel)));
 }
 
-function searchSuggestions(searchString: string, context: SuggestionSortContext): SearchSuggestion[] {
+function searchSuggestions(
+  searchString: string,
+  context: SuggestionSortContext
+): SearchSuggestion[] {
   if (!searchString) return [];
   const geoJSON = getBuildingGeoJSON();
   const suggestions = geoJSON.features

--- a/src/services/buildingService.ts
+++ b/src/services/buildingService.ts
@@ -14,6 +14,13 @@ import { booleanContainsPoint } from "bbox-fns";
 import BackendService from "./backendService";
 import { getRequiredFeatureId, getRequiredFeatureProperties } from "../utils/geoJsonHelpers";
 
+export interface SearchSuggestion {
+  id: string;
+  displayName: string;
+  levels: number[];
+  feature: GeoJSON.Feature;
+}
+
 /**
  * Finding a building by search string:
  * 1) Iterate through all building Features if there is a Feature with the given name. If so, return the building Feature.
@@ -127,6 +134,33 @@ function filterByString(f: GeoJSON.Feature, searchString: string) {
   );
 }
 
+function filterForSuggestions(f: GeoJSON.Feature, searchString: string): boolean {
+  const p = getRequiredFeatureProperties(f);
+  const s = searchString.toLowerCase();
+  return !!(
+    p.name?.toLowerCase().includes(s) ||
+    p.ref?.toLowerCase().startsWith(s) ||
+    p.indoor?.toLowerCase().startsWith(s) ||
+    p.amenity?.toLowerCase().startsWith(s)
+  );
+}
+
+function searchSuggestions(searchString: string): SearchSuggestion[] {
+  if (!searchString) return [];
+  const geoJSON = getBuildingGeoJSON();
+  return geoJSON.features
+    .filter((f) => filterForSuggestions(f, searchString))
+    .map((f) => {
+      const p = getRequiredFeatureProperties(f);
+      return {
+        id: getRequiredFeatureId(f),
+        displayName: (p.name ?? p.ref ?? p.indoor ?? p.amenity ?? "?") as string,
+        levels: Array.isArray(p.level) ? (p.level as number[]) : [],
+        feature: f,
+      };
+    });
+}
+
 // /*Filter*/
 export function filterByBounds(
   geoJSON: GeoJsonObject,
@@ -233,6 +267,7 @@ export default {
   getBuildingDescription,
   handleSearch,
   runIndoorSearch,
+  searchSuggestions,
   filterByBounds,
   filterInsideAndLevel
 };

--- a/src/services/buildingService.ts
+++ b/src/services/buildingService.ts
@@ -194,16 +194,49 @@ function getFeatureCentroid(
   return undefined;
 }
 
+const FIELD_PRIORITY: Record<"name" | "ref" | "amenity", number> = {
+  name: 0,
+  ref: 1,
+  amenity: 2,
+};
+const QUALITY_TIER_COUNT = 3; // exact, prefix, substring
+
+function matchQuality(value: string | undefined, query: string): number | undefined {
+  if (!value) return undefined;
+  const v = value.toLowerCase();
+  if (v === query) return 0;
+  if (v.startsWith(query)) return 1;
+  if (v.includes(query)) return 2;
+  return undefined;
+}
+
+/**
+ * Scores a feature's relevance to a search query across its name, ref and
+ * amenity fields, then combines them so a better match on a lower-priority
+ * field still ranks close to a worse match on a higher-priority field
+ * (e.g. an exact ref match ranks just behind a substring name match).
+ * Lower is better. Reorder FIELD_PRIORITY to change field precedence.
+ */
 function matchScore(
-  displayName: string,
-  query: string
+  p: Record<string, unknown>,
+  validName: string | undefined,
+  searchString: string
 ): number {
-  const name = displayName.toLowerCase();
-  const q = query.toLowerCase();
-  if (name === q) return 0;
-  if (name.startsWith(q)) return 1;
-  if (name.includes(q)) return 2;
-  return 3;
+  const query = searchString.toLowerCase();
+  const fieldValues: Array<[keyof typeof FIELD_PRIORITY, string | undefined]> = [
+    ["name", validName],
+    ["ref", p.ref as string | undefined],
+    ["amenity", p.amenity as string | undefined],
+  ];
+
+  const scores = fieldValues
+    .map(([field, value]) => {
+      const quality = matchQuality(value, query);
+      return quality === undefined ? undefined : FIELD_PRIORITY[field] * QUALITY_TIER_COUNT + quality;
+    })
+    .filter((score): score is number => score !== undefined);
+
+  return Math.min(...scores);
 }
 
 function minLevelDistance(
@@ -246,7 +279,11 @@ function searchSuggestions(
     (a[0] - b[0]) ** 2 + (a[1] - b[1]) ** 2;
 
   return suggestions.sort((a, b) => {
-    const matchDiff = matchScore(a.displayName, searchString) - matchScore(b.displayName, searchString);
+    const propsA = getRequiredFeatureProperties(a.feature);
+    const propsB = getRequiredFeatureProperties(b.feature);
+    const matchDiff =
+      matchScore(propsA, getValidName(propsA), searchString) -
+      matchScore(propsB, getValidName(propsB), searchString);
     if (matchDiff !== 0) return matchDiff;
 
     const levelDiff = minLevelDistance(a.levels, context.currentLevel) - minLevelDistance(b.levels, context.currentLevel);

--- a/src/services/buildingService.ts
+++ b/src/services/buildingService.ts
@@ -14,6 +14,8 @@ import { booleanContainsPoint } from "bbox-fns";
 import BackendService from "./backendService";
 import { getRequiredFeatureId, getRequiredFeatureProperties } from "../utils/geoJsonHelpers";
 import { getFeatureLevels } from "../utils/featureLevels";
+import { chainComparators } from "../utils/compareChain";
+import { getRequiredMapValue } from "../utils/requiredHelpers";
 
 export interface SearchSuggestion {
   id: string;
@@ -252,17 +254,24 @@ function searchSuggestions(
 ): SearchSuggestion[] {
   if (!searchString) return [];
   const geoJSON = getBuildingGeoJSON();
-  const suggestions = geoJSON.features
+  const suggestions: SearchSuggestion[] = [];
+  const scores = new Map<string, number>();
+
+  geoJSON.features
     .filter((f) => filterForSuggestions(f, searchString))
-    .map((f) => {
+    .forEach((f) => {
       const p = getRequiredFeatureProperties(f);
-      return {
-        id: getRequiredFeatureId(f),
-        displayName: (getValidName(p) ?? p.ref ?? p.indoor ?? p.amenity ?? "?") as string,
+      const validName = getValidName(p);
+      const id = getRequiredFeatureId(f);
+
+      suggestions.push({
+        id,
+        displayName: (validName ?? p.ref ?? p.indoor ?? p.amenity ?? "?") as string,
         levels: getFeatureLevels(f),
         type: (p.amenity ?? p.indoor) as string | undefined,
         feature: f,
-      };
+      });
+      scores.set(id, matchScore(p, validName, searchString));
     });
 
   const centroids = new Map<string, [number, number] | undefined>(
@@ -278,37 +287,29 @@ function searchSuggestions(
   const squaredDist = (a: [number, number], b: [number, number]): number =>
     (a[0] - b[0]) ** 2 + (a[1] - b[1]) ** 2;
 
-  return suggestions.sort((a, b) => {
-    const propsA = getRequiredFeatureProperties(a.feature);
-    const propsB = getRequiredFeatureProperties(b.feature);
-    const matchDiff =
-      matchScore(propsA, getValidName(propsA), searchString) -
-      matchScore(propsB, getValidName(propsB), searchString);
-    if (matchDiff !== 0) return matchDiff;
+  const byMatchScore = (a: SearchSuggestion, b: SearchSuggestion): number =>
+    getRequiredMapValue(scores, a.id, "Search suggestion score") -
+    getRequiredMapValue(scores, b.id, "Search suggestion score");
 
-    const levelDiff = minLevelDistance(a.levels, context.currentLevel) - minLevelDistance(b.levels, context.currentLevel);
-    if (levelDiff !== 0) return levelDiff;
+  const byLevelDistance = (a: SearchSuggestion, b: SearchSuggestion): number =>
+    minLevelDistance(a.levels, context.currentLevel) - minLevelDistance(b.levels, context.currentLevel);
 
-    if (selectedCoords) {
+  const byProximityTo = (coords: [number, number] | undefined) =>
+    (a: SearchSuggestion, b: SearchSuggestion): number => {
+      if (!coords) return 0;
       const ca = centroids.get(a.id);
       const cb = centroids.get(b.id);
-      if (ca && cb) {
-        const diff = squaredDist(ca, selectedCoords) - squaredDist(cb, selectedCoords);
-        if (diff !== 0) return diff;
-      }
-    }
+      if (!ca || !cb) return 0;
+      return squaredDist(ca, coords) - squaredDist(cb, coords);
+    };
 
-    if (infoCoords) {
-      const ca = centroids.get(a.id);
-      const cb = centroids.get(b.id);
-      if (ca && cb) {
-        const diff = squaredDist(ca, infoCoords) - squaredDist(cb, infoCoords);
-        if (diff !== 0) return diff;
-      }
-    }
-
-    return 0;
-  });
+  // Priority order, most important first. Reorder this list to change ranking behavior.
+  return suggestions.sort(chainComparators(
+    byMatchScore,
+    byLevelDistance,
+    byProximityTo(selectedCoords),
+    byProximityTo(infoCoords)
+  ));
 }
 
 // /*Filter*/

--- a/src/services/buildingService.ts
+++ b/src/services/buildingService.ts
@@ -136,6 +136,7 @@ function filterByString(f: GeoJSON.Feature, searchString: string) {
 }
 
 const OSM_NAME_ARTIFACTS = new Set(["yes", "no"]);
+const EXCLUDED_AMENITIES = new Set(["waste_basket"]);
 
 function getValidName(p: Record<string, unknown>): string | undefined {
   const name = p.name;
@@ -145,6 +146,7 @@ function getValidName(p: Record<string, unknown>): string | undefined {
 
 function filterForSuggestions(f: GeoJSON.Feature, searchString: string): boolean {
   const p = getRequiredFeatureProperties(f);
+  if (p.amenity && EXCLUDED_AMENITIES.has(String(p.amenity))) return false;
   const s = searchString.toLowerCase();
   return !!(
     getValidName(p)?.toLowerCase().includes(s) ||

--- a/src/services/buildingService.ts
+++ b/src/services/buildingService.ts
@@ -140,7 +140,7 @@ function filterByString(f: GeoJSON.Feature, searchString: string) {
   );
 }
 
-const OSM_NAME_ARTIFACTS = new Set(["yes", "no"]);
+const OSM_NAME_ARTIFACTS = new Set([]);
 const EXCLUDED_AMENITIES = new Set(["waste_basket"]);
 
 function getValidName(p: Record<string, unknown>): string | undefined {

--- a/src/services/buildingService.ts
+++ b/src/services/buildingService.ts
@@ -18,6 +18,7 @@ export interface SearchSuggestion {
   id: string;
   displayName: string;
   levels: number[];
+  type: string | undefined;
   feature: GeoJSON.Feature;
 }
 
@@ -155,6 +156,7 @@ function searchSuggestions(searchString: string): SearchSuggestion[] {
         id: getRequiredFeatureId(f),
         displayName: (p.name ?? p.ref ?? p.indoor ?? p.amenity ?? "?") as string,
         levels: Array.isArray(p.level) ? (p.level as number[]) : [],
+        type: (p.amenity ?? p.indoor) as string | undefined,
         feature: f,
       };
     });

--- a/src/services/featureService.ts
+++ b/src/services/featureService.ts
@@ -4,6 +4,7 @@ import UserService from "../services/userService";
 import { lang } from "./languageService";
 import {
   MARKERS_IMG_DIR,
+  ICONS,
 } from "../../public/strings/constants.json";
 import {
   FILL_OPACITY,
@@ -91,6 +92,44 @@ function getAccessibilityMarkerData(feature: GeoJSON.Feature): AccessibilityMark
     };
   }
   return null;
+}
+
+const CATEGORY_ICON_RULES: Array<{ matches: (p: Record<string, unknown>) => boolean; iconFilename: string }> = [
+  {
+    matches: (p) => p.amenity === "toilets" && ["yes", "designated"].includes(p.wheelchair as string),
+    iconFilename: ICONS.TOILETS_WHEELCHAIR,
+  },
+  { matches: (p) => p.amenity === "toilets", iconFilename: ICONS.TOILETS },
+  { matches: (p) => p.highway === "elevator", iconFilename: ICONS.ELEVATOR },
+  { matches: (p) => p.highway === "steps" || p.stairs === "yes", iconFilename: ICONS.STAIRS },
+  { matches: (p) => p.amenity === "cafe" || p.amenity === "restaurant", iconFilename: ICONS.CAFE },
+  { matches: (p) => p.shop !== undefined, iconFilename: ICONS.SHOP },
+  {
+    matches: (p) => p.entrance !== undefined && ["yes", "main", "secondary"].includes(p.entrance as string),
+    iconFilename: ICONS.ENTRANCE,
+  },
+  {
+    matches: (p) =>
+      (p.exit !== undefined && ["yes", "emergency"].includes(p.exit as string)) ||
+      (p.entrance !== undefined && ["exit", "emergency"].includes(p.entrance as string)),
+    iconFilename: ICONS.EMERGENCY_EXIT,
+  },
+  {
+    matches: (p) => p.information !== undefined && ["board", "map"].includes(p.information as string),
+    iconFilename: ICONS.INFO,
+  },
+];
+
+/**
+ * Profile-agnostic category icon for a feature, for use in contexts (like
+ * search results) where the icon must stay consistent regardless of the
+ * user's currently-selected accessibility profile or toggled map filters.
+ * Falls back to a generic icon so callers always get a usable path.
+ */
+export function getCategoryIcon(feature: GeoJSON.Feature): string {
+  const properties = getRequiredFeatureProperties(feature);
+  const rule = CATEGORY_ICON_RULES.find(({ matches }) => matches(properties));
+  return MARKERS_IMG_DIR + (rule ? rule.iconFilename : ICONS.ADDITIONAL);
 }
 
 function getFeatureStyle(feature: GeoJSON.Feature<any>): any {
@@ -205,4 +244,5 @@ export default {
   isStaircase,
   isSimpleStaircase,
   isComplexStaircase,
+  getCategoryIcon,
 };

--- a/src/services/featureService.ts
+++ b/src/services/featureService.ts
@@ -124,12 +124,12 @@ const CATEGORY_ICON_RULES: Array<{ matches: (p: Record<string, unknown>) => bool
  * Profile-agnostic category icon for a feature, for use in contexts (like
  * search results) where the icon must stay consistent regardless of the
  * user's currently-selected accessibility profile or toggled map filters.
- * Falls back to a generic icon so callers always get a usable path.
+ * Returns undefined when no specific category icon applies.
  */
-export function getCategoryIcon(feature: GeoJSON.Feature): string {
+export function getCategoryIcon(feature: GeoJSON.Feature): string | undefined {
   const properties = getRequiredFeatureProperties(feature);
   const rule = CATEGORY_ICON_RULES.find(({ matches }) => matches(properties));
-  return MARKERS_IMG_DIR + (rule ? rule.iconFilename : ICONS.ADDITIONAL);
+  return rule ? MARKERS_IMG_DIR + rule.iconFilename : undefined;
 }
 
 function getFeatureStyle(feature: GeoJSON.Feature<any>): any {

--- a/src/utils/compareChain.ts
+++ b/src/utils/compareChain.ts
@@ -1,0 +1,16 @@
+export type Comparator<T> = (a: T, b: T) => number;
+
+/**
+ * Combines comparators into one, applying them in order and returning the
+ * first non-zero result (or 0 if every comparator ties). Reorder the
+ * arguments at the call site to change priority.
+ */
+export function chainComparators<T>(...comparators: Comparator<T>[]): Comparator<T> {
+  return (a, b) => {
+    for (const comparator of comparators) {
+      const result = comparator(a, b);
+      if (result !== 0) return result;
+    }
+    return 0;
+  };
+}

--- a/src/utils/featureLevels.ts
+++ b/src/utils/featureLevels.ts
@@ -1,0 +1,12 @@
+import { extractLevels } from "./extractLevels";
+import { getRequiredFeatureProperties } from "./geoJsonHelpers";
+
+export function getFeatureLevels(feature: GeoJSON.Feature): number[] {
+  const properties = getRequiredFeatureProperties(feature);
+  const levels = [
+    ...extractLevels(properties.level),
+    ...extractLevels(properties.repeat_on),
+  ];
+
+  return Array.from(new Set(levels));
+}

--- a/test/components/searchForm.test.ts
+++ b/test/components/searchForm.test.ts
@@ -77,7 +77,7 @@ describe("searchForm", () => {
   });
 
   function pressEnter(): void {
-    input.dispatchEvent(new KeyboardEvent("keyup", { key: "Enter" }));
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
   }
 
   it("shows an error and does not search when the input is empty", () => {
@@ -100,6 +100,26 @@ describe("searchForm", () => {
 
     expect(geoMap.selectIndoorFeature).toHaveBeenCalledWith(feature);
     expect(input.value).toBe("Room A");
+  });
+
+  it("reruns suggestions on submit and selects the current first result", () => {
+    const staleFeature: GeoJSON.Feature = { id: "way/1", type: "Feature", properties: {}, geometry: { type: "Polygon", coordinates: [] } };
+    const currentFeature: GeoJSON.Feature = { id: "way/2", type: "Feature", properties: {}, geometry: { type: "Polygon", coordinates: [] } };
+    const staleSuggestion = { id: "way/1", displayName: "Room A", levels: [0], type: "room", feature: staleFeature };
+    const currentSuggestion = { id: "way/2", displayName: "Room B", levels: [0], type: "room", feature: currentFeature };
+    (BuildingService.searchSuggestions as jest.Mock)
+      .mockReturnValueOnce([staleSuggestion])
+      .mockReturnValueOnce([currentSuggestion]);
+
+    SearchForm.render(geoMap);
+    input.value = "room";
+    input.dispatchEvent(new Event("input"));
+    pressEnter();
+
+    expect(SearchSuggestions.update).toHaveBeenCalledWith([staleSuggestion]);
+    expect(BuildingService.searchSuggestions).toHaveBeenCalledTimes(2);
+    expect(geoMap.selectIndoorFeature).toHaveBeenCalledWith(currentFeature);
+    expect(input.value).toBe("Room B");
   });
 
   it("shows a not-found error when Enter is pressed with no matches", () => {

--- a/test/components/searchForm.test.ts
+++ b/test/components/searchForm.test.ts
@@ -1,0 +1,115 @@
+/**
+ * @jest-environment jsdom
+ */
+jest.mock("../../src/services/languageService", () => ({
+  lang: {
+    indoorSearchSubmit: "Search",
+    indoorSearchPlaceholder: "Search indoor",
+    searchEmpty: "Please enter a search term!",
+    searchNotFound: "Not found!",
+  },
+}));
+jest.mock("../../src/services/buildingService", () => ({
+  __esModule: true,
+  default: {
+    getBuildingGeoJSON: jest.fn(() => ({ type: "FeatureCollection", features: [] as GeoJSON.Feature[] })),
+    searchSuggestions: jest.fn(),
+  },
+}));
+jest.mock("../../src/components/ui/searchSuggestions", () => ({
+  __esModule: true,
+  default: {
+    render: jest.fn(),
+    update: jest.fn(),
+    clear: jest.fn(),
+  },
+}));
+jest.mock("../../src/components/ui/loadingIndicator", () => ({
+  __esModule: true,
+  default: { error: jest.fn(), start: jest.fn(), end: jest.fn() },
+}));
+jest.mock("../../src/services/userService", () => ({
+  __esModule: true,
+  default: { getCurrentProfile: jest.fn(() => 2) }, // UserGroupEnum.noImpairments
+}));
+
+import type { GeoMap } from "../../src/components/geoMap";
+import type BuildingServiceType from "../../src/services/buildingService";
+import type LoadingIndicatorType from "../../src/components/ui/loadingIndicator";
+
+describe("searchForm", () => {
+  let SearchForm: typeof import("../../src/components/ui/searchForm").default;
+  let BuildingService: typeof BuildingServiceType;
+  let LoadingIndicator: typeof LoadingIndicatorType;
+  let input: HTMLInputElement;
+  let submitButton: HTMLButtonElement;
+  let geoMap: GeoMap;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    document.body.innerHTML = `
+      <input id="indoorSearchInput" />
+      <button id="indoorSearchSubmit"></button>
+    `;
+    BuildingService = require("../../src/services/buildingService").default;
+    LoadingIndicator = require("../../src/components/ui/loadingIndicator").default;
+    SearchForm = require("../../src/components/ui/searchForm").default;
+    input = document.getElementById("indoorSearchInput") as HTMLInputElement;
+    submitButton = document.getElementById("indoorSearchSubmit") as HTMLButtonElement;
+    geoMap = {
+      currentLevel: 0,
+      selectedFeatures: [],
+      infoPoint: { type: "Feature", properties: {}, geometry: { type: "GeometryCollection", geometries: [] } },
+      selectIndoorFeature: jest.fn(),
+    } as unknown as GeoMap;
+  });
+
+  function pressEnter(): void {
+    input.dispatchEvent(new KeyboardEvent("keyup", { key: "Enter" }));
+  }
+
+  it("shows an error and does not search when the input is empty", () => {
+    SearchForm.render(geoMap);
+    input.value = "";
+    pressEnter();
+    expect(LoadingIndicator.error).toHaveBeenCalledWith("Please enter a search term!");
+    expect(BuildingService.searchSuggestions).not.toHaveBeenCalled();
+  });
+
+  it("selects the first search result when Enter is pressed", () => {
+    const feature: GeoJSON.Feature = { id: "way/1", type: "Feature", properties: {}, geometry: { type: "Polygon", coordinates: [] } };
+    const suggestion = { id: "way/1", displayName: "Room A", levels: [0], type: "room", feature };
+    (BuildingService.searchSuggestions as jest.Mock).mockReturnValue([suggestion]);
+
+    SearchForm.render(geoMap);
+    input.value = "room";
+    pressEnter();
+
+    expect(geoMap.selectIndoorFeature).toHaveBeenCalledWith(feature);
+    expect(input.value).toBe("Room A");
+  });
+
+  it("shows a not-found error when Enter is pressed with no matches", () => {
+    (BuildingService.searchSuggestions as jest.Mock).mockReturnValue([]);
+
+    SearchForm.render(geoMap);
+    input.value = "xyzzy";
+    pressEnter();
+
+    expect(LoadingIndicator.error).toHaveBeenCalledWith("Not found!");
+    expect(geoMap.selectIndoorFeature).not.toHaveBeenCalled();
+  });
+
+  it("selects the first result when the Search button is clicked", () => {
+    const feature: GeoJSON.Feature = { id: "way/2", type: "Feature", properties: {}, geometry: { type: "Polygon", coordinates: [] } };
+    const suggestion = { id: "way/2", displayName: "Room B", levels: [0], type: "room", feature };
+    (BuildingService.searchSuggestions as jest.Mock).mockReturnValue([suggestion]);
+
+    SearchForm.render(geoMap);
+    input.value = "room b";
+    submitButton.click();
+
+    expect(geoMap.selectIndoorFeature).toHaveBeenCalledWith(feature);
+  });
+});

--- a/test/components/searchForm.test.ts
+++ b/test/components/searchForm.test.ts
@@ -24,10 +24,6 @@ jest.mock("../../src/components/ui/searchSuggestions", () => ({
     clear: jest.fn(),
   },
 }));
-jest.mock("../../src/components/ui/loadingIndicator", () => ({
-  __esModule: true,
-  default: { error: jest.fn(), start: jest.fn(), end: jest.fn() },
-}));
 jest.mock("../../src/services/userService", () => ({
   __esModule: true,
   default: { getCurrentProfile: jest.fn(() => 2) }, // UserGroupEnum.noImpairments
@@ -35,14 +31,13 @@ jest.mock("../../src/services/userService", () => ({
 
 import type { GeoMap } from "../../src/components/geoMap";
 import type BuildingServiceType from "../../src/services/buildingService";
-import type LoadingIndicatorType from "../../src/components/ui/loadingIndicator";
 
 describe("searchForm", () => {
   let SearchForm: typeof import("../../src/components/ui/searchForm").default;
   let BuildingService: typeof BuildingServiceType;
-  let LoadingIndicator: typeof LoadingIndicatorType;
   let input: HTMLInputElement;
   let submitButton: HTMLButtonElement;
+  let errorMessage: HTMLDivElement;
   let geoMap: GeoMap;
 
   beforeEach(() => {
@@ -51,12 +46,13 @@ describe("searchForm", () => {
     document.body.innerHTML = `
       <input id="indoorSearchInput" />
       <button id="indoorSearchSubmit"></button>
+      <div id="searchErrorMessage"></div>
     `;
     BuildingService = require("../../src/services/buildingService").default;
-    LoadingIndicator = require("../../src/components/ui/loadingIndicator").default;
     SearchForm = require("../../src/components/ui/searchForm").default;
     input = document.getElementById("indoorSearchInput") as HTMLInputElement;
     submitButton = document.getElementById("indoorSearchSubmit") as HTMLButtonElement;
+    errorMessage = document.getElementById("searchErrorMessage") as HTMLDivElement;
     geoMap = {
       currentLevel: 0,
       selectedFeatures: [],
@@ -73,7 +69,8 @@ describe("searchForm", () => {
     SearchForm.render(geoMap);
     input.value = "";
     pressEnter();
-    expect(LoadingIndicator.error).toHaveBeenCalledWith("Please enter a search term!");
+    expect(errorMessage.textContent).toBe("Please enter a search term!");
+    expect(errorMessage.classList.contains("visible")).toBe(true);
     expect(BuildingService.searchSuggestions).not.toHaveBeenCalled();
   });
 
@@ -97,8 +94,23 @@ describe("searchForm", () => {
     input.value = "xyzzy";
     pressEnter();
 
-    expect(LoadingIndicator.error).toHaveBeenCalledWith("Not found!");
+    expect(errorMessage.textContent).toBe("Not found!");
+    expect(errorMessage.classList.contains("visible")).toBe(true);
     expect(geoMap.selectIndoorFeature).not.toHaveBeenCalled();
+  });
+
+  it("clears a shown error as soon as the user types again", () => {
+    (BuildingService.searchSuggestions as jest.Mock).mockReturnValue([]);
+    SearchForm.render(geoMap);
+    input.value = "xyzzy";
+    pressEnter();
+    expect(errorMessage.classList.contains("visible")).toBe(true);
+
+    input.value = "xyzzy2";
+    input.dispatchEvent(new Event("input"));
+
+    expect(errorMessage.classList.contains("visible")).toBe(false);
+    expect(errorMessage.textContent).toBe("");
   });
 
   it("selects the first result when the Search button is clicked", () => {

--- a/test/components/searchForm.test.ts
+++ b/test/components/searchForm.test.ts
@@ -7,6 +7,8 @@ jest.mock("../../src/services/languageService", () => ({
     indoorSearchPlaceholder: "Search indoor",
     searchEmpty: "Please enter a search term!",
     searchNotFound: "Not found!",
+    clearIndoorSearch: "Clear indoor search field",
+    clearSearchError: "Dismiss search error",
   },
 }));
 jest.mock("../../src/services/buildingService", () => ({
@@ -31,13 +33,18 @@ jest.mock("../../src/services/userService", () => ({
 
 import type { GeoMap } from "../../src/components/geoMap";
 import type BuildingServiceType from "../../src/services/buildingService";
+import type SearchSuggestionsType from "../../src/components/ui/searchSuggestions";
 
 describe("searchForm", () => {
   let SearchForm: typeof import("../../src/components/ui/searchForm").default;
   let BuildingService: typeof BuildingServiceType;
+  let SearchSuggestions: typeof SearchSuggestionsType;
   let input: HTMLInputElement;
   let submitButton: HTMLButtonElement;
+  let clearButton: HTMLButtonElement;
   let errorMessage: HTMLDivElement;
+  let errorText: HTMLSpanElement;
+  let errorClearButton: HTMLButtonElement;
   let geoMap: GeoMap;
 
   beforeEach(() => {
@@ -45,14 +52,22 @@ describe("searchForm", () => {
     jest.clearAllMocks();
     document.body.innerHTML = `
       <input id="indoorSearchInput" />
+      <button id="indoorSearchClear"></button>
       <button id="indoorSearchSubmit"></button>
-      <div id="searchErrorMessage"></div>
+      <div id="searchErrorMessage">
+        <span id="searchErrorText"></span>
+        <button id="searchErrorClear"></button>
+      </div>
     `;
     BuildingService = require("../../src/services/buildingService").default;
+    SearchSuggestions = require("../../src/components/ui/searchSuggestions").default;
     SearchForm = require("../../src/components/ui/searchForm").default;
     input = document.getElementById("indoorSearchInput") as HTMLInputElement;
     submitButton = document.getElementById("indoorSearchSubmit") as HTMLButtonElement;
+    clearButton = document.getElementById("indoorSearchClear") as HTMLButtonElement;
     errorMessage = document.getElementById("searchErrorMessage") as HTMLDivElement;
+    errorText = document.getElementById("searchErrorText") as HTMLSpanElement;
+    errorClearButton = document.getElementById("searchErrorClear") as HTMLButtonElement;
     geoMap = {
       currentLevel: 0,
       selectedFeatures: [],
@@ -69,7 +84,7 @@ describe("searchForm", () => {
     SearchForm.render(geoMap);
     input.value = "";
     pressEnter();
-    expect(errorMessage.textContent).toBe("Please enter a search term!");
+    expect(errorText.textContent).toBe("Please enter a search term!");
     expect(errorMessage.classList.contains("visible")).toBe(true);
     expect(BuildingService.searchSuggestions).not.toHaveBeenCalled();
   });
@@ -94,7 +109,7 @@ describe("searchForm", () => {
     input.value = "xyzzy";
     pressEnter();
 
-    expect(errorMessage.textContent).toBe("Not found!");
+    expect(errorText.textContent).toBe("Not found!");
     expect(errorMessage.classList.contains("visible")).toBe(true);
     expect(geoMap.selectIndoorFeature).not.toHaveBeenCalled();
   });
@@ -110,7 +125,7 @@ describe("searchForm", () => {
     input.dispatchEvent(new Event("input"));
 
     expect(errorMessage.classList.contains("visible")).toBe(false);
-    expect(errorMessage.textContent).toBe("");
+    expect(errorText.textContent).toBe("");
   });
 
   it("selects the first result when the Search button is clicked", () => {
@@ -123,5 +138,33 @@ describe("searchForm", () => {
     submitButton.click();
 
     expect(geoMap.selectIndoorFeature).toHaveBeenCalledWith(feature);
+  });
+
+  it("clears the input, suggestions, and visible error when the clear search button is clicked", () => {
+    (BuildingService.searchSuggestions as jest.Mock).mockReturnValue([]);
+    SearchForm.render(geoMap);
+    input.value = "xyzzy";
+    pressEnter();
+    expect(errorMessage.classList.contains("visible")).toBe(true);
+
+    clearButton.click();
+
+    expect(input.value).toBe("");
+    expect(errorText.textContent).toBe("");
+    expect(errorMessage.classList.contains("visible")).toBe(false);
+    expect(SearchSuggestions.clear).toHaveBeenCalled();
+  });
+
+  it("clears a visible search error when the error dismiss button is clicked", () => {
+    (BuildingService.searchSuggestions as jest.Mock).mockReturnValue([]);
+    SearchForm.render(geoMap);
+    input.value = "xyzzy";
+    pressEnter();
+
+    errorClearButton.click();
+
+    expect(input.value).toBe("xyzzy");
+    expect(errorText.textContent).toBe("");
+    expect(errorMessage.classList.contains("visible")).toBe(false);
   });
 });

--- a/test/components/searchSuggestions.test.ts
+++ b/test/components/searchSuggestions.test.ts
@@ -1,0 +1,62 @@
+/**
+ * @jest-environment jsdom
+ */
+jest.mock("../../src/services/languageService", () => ({
+  lang: { searchSuggestionLevel: "Level " },
+}));
+
+import type { SearchSuggestion } from "../../src/services/buildingService";
+
+function suggestion(overrides: Partial<SearchSuggestion> = {}): SearchSuggestion {
+  return {
+    id: "way/1",
+    displayName: "Room A",
+    levels: [0],
+    type: "room",
+    feature: {
+      id: "way/1",
+      type: "Feature",
+      geometry: { type: "Polygon", coordinates: [] },
+      properties: {},
+    },
+    ...overrides,
+  };
+}
+
+describe("SearchSuggestions", () => {
+  let SearchSuggestions: typeof import("../../src/components/ui/searchSuggestions").default;
+
+  beforeEach(() => {
+    jest.resetModules();
+    document.body.innerHTML = `<ul id="searchSuggestionsList" aria-label="Search suggestions"></ul>`;
+    SearchSuggestions = require("../../src/components/ui/searchSuggestions").default;
+  });
+
+  it("renders each suggestion as a focusable, labeled button", () => {
+    SearchSuggestions.update([suggestion()]);
+    const button = document.querySelector<HTMLButtonElement>("#searchSuggestionsList button");
+    expect(button).not.toBeNull();
+    expect(button?.getAttribute("type")).toBe("button");
+    expect(button?.getAttribute("aria-label")).toContain("Room A");
+  });
+
+  it("calls onSelect and clears the list when a card is activated", () => {
+    const onSelect = jest.fn();
+    SearchSuggestions.render(onSelect);
+    const s = suggestion();
+    SearchSuggestions.update([s]);
+
+    const button = document.querySelector<HTMLButtonElement>("#searchSuggestionsList button")!;
+    button.click();
+
+    expect(onSelect).toHaveBeenCalledWith(s);
+    expect(document.getElementById("searchSuggestionsList")?.classList.contains("visible")).toBe(false);
+    expect(document.querySelectorAll("#searchSuggestionsList button")).toHaveLength(0);
+  });
+
+  it("clears the rendered list", () => {
+    SearchSuggestions.update([suggestion()]);
+    SearchSuggestions.clear();
+    expect(document.querySelectorAll("#searchSuggestionsList button")).toHaveLength(0);
+  });
+});

--- a/test/components/searchSuggestions.test.ts
+++ b/test/components/searchSuggestions.test.ts
@@ -5,6 +5,10 @@ jest.mock("../../src/services/languageService", () => ({
   lang: { searchSuggestionLevel: "Level " },
 }));
 
+jest.mock("../../src/services/featureService", () => ({
+  getCategoryIcon: jest.fn(() => "/images/additional.svg"),
+}));
+
 import type { SearchSuggestion } from "../../src/services/buildingService";
 
 function suggestion(overrides: Partial<SearchSuggestion> = {}): SearchSuggestion {
@@ -38,6 +42,15 @@ describe("SearchSuggestions", () => {
     expect(button).not.toBeNull();
     expect(button?.getAttribute("type")).toBe("button");
     expect(button?.getAttribute("aria-label")).toContain("Room A");
+  });
+
+  it("renders a decorative category icon for each suggestion", () => {
+    SearchSuggestions.update([suggestion()]);
+    const icon = document.querySelector<HTMLImageElement>("#searchSuggestionsList img.suggestion-icon");
+    expect(icon).not.toBeNull();
+    expect(icon?.getAttribute("src")).toBe("/images/additional.svg");
+    expect(icon?.getAttribute("alt")).toBe("");
+    expect(icon?.getAttribute("aria-hidden")).toBe("true");
   });
 
   it("calls onSelect and clears the list when a card is activated", () => {

--- a/test/components/searchSuggestions.test.ts
+++ b/test/components/searchSuggestions.test.ts
@@ -6,7 +6,7 @@ jest.mock("../../src/services/languageService", () => ({
 }));
 
 jest.mock("../../src/services/featureService", () => ({
-  getCategoryIcon: jest.fn(() => "/images/additional.svg"),
+  getCategoryIcon: jest.fn(),
 }));
 
 import type { SearchSuggestion } from "../../src/services/buildingService";
@@ -29,10 +29,13 @@ function suggestion(overrides: Partial<SearchSuggestion> = {}): SearchSuggestion
 
 describe("SearchSuggestions", () => {
   let SearchSuggestions: typeof import("../../src/components/ui/searchSuggestions").default;
+  let getCategoryIcon: jest.Mock;
 
   beforeEach(() => {
     jest.resetModules();
+    jest.clearAllMocks();
     document.body.innerHTML = `<ul id="searchSuggestionsList" aria-label="Search suggestions"></ul>`;
+    getCategoryIcon = require("../../src/services/featureService").getCategoryIcon;
     SearchSuggestions = require("../../src/components/ui/searchSuggestions").default;
   });
 
@@ -44,11 +47,19 @@ describe("SearchSuggestions", () => {
     expect(button?.getAttribute("aria-label")).toContain("Room A");
   });
 
-  it("renders a decorative category icon for each suggestion", () => {
+  it("does not render a category icon when none is configured", () => {
+    getCategoryIcon.mockReturnValue(undefined);
+    SearchSuggestions.update([suggestion()]);
+    const icon = document.querySelector<HTMLImageElement>("#searchSuggestionsList img.suggestion-icon");
+    expect(icon).toBeNull();
+  });
+
+  it("renders a decorative category icon when one is configured", () => {
+    getCategoryIcon.mockReturnValue("/images/toilets.svg");
     SearchSuggestions.update([suggestion()]);
     const icon = document.querySelector<HTMLImageElement>("#searchSuggestionsList img.suggestion-icon");
     expect(icon).not.toBeNull();
-    expect(icon?.getAttribute("src")).toBe("/images/additional.svg");
+    expect(icon?.getAttribute("src")).toBe("/images/toilets.svg");
     expect(icon?.getAttribute("alt")).toBe("");
     expect(icon?.getAttribute("aria-hidden")).toBe("true");
   });

--- a/test/components/searchSuggestions.test.ts
+++ b/test/components/searchSuggestions.test.ts
@@ -2,7 +2,11 @@
  * @jest-environment jsdom
  */
 jest.mock("../../src/services/languageService", () => ({
-  lang: { searchSuggestionLevel: "Level " },
+  lang: {
+    searchSuggestionLevel: "Level ",
+    searchSuggestionsAvailable: "{count} search suggestions available.",
+    searchSuggestionsNone: "No search suggestions available.",
+  },
 }));
 
 jest.mock("../../src/services/featureService", () => ({
@@ -30,21 +34,34 @@ function suggestion(overrides: Partial<SearchSuggestion> = {}): SearchSuggestion
 describe("SearchSuggestions", () => {
   let SearchSuggestions: typeof import("../../src/components/ui/searchSuggestions").default;
   let getCategoryIcon: jest.Mock;
+  let input: HTMLInputElement;
 
   beforeEach(() => {
     jest.resetModules();
     jest.clearAllMocks();
-    document.body.innerHTML = `<ul id="searchSuggestionsList" aria-label="Search suggestions"></ul>`;
+    jest.useFakeTimers();
+    document.body.innerHTML = `
+      <input id="indoorSearchInput" aria-expanded="false" aria-activedescendant="" />
+      <ul id="searchSuggestionsList" role="listbox" aria-label="Search suggestions"></ul>
+      <div id="searchAnnouncement" aria-live="polite" aria-atomic="true"></div>
+    `;
+    input = document.getElementById("indoorSearchInput") as HTMLInputElement;
     getCategoryIcon = require("../../src/services/featureService").getCategoryIcon;
     SearchSuggestions = require("../../src/components/ui/searchSuggestions").default;
   });
 
-  it("renders each suggestion as a focusable, labeled button", () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("renders each suggestion as a labeled listbox option", () => {
     SearchSuggestions.update([suggestion()]);
-    const button = document.querySelector<HTMLButtonElement>("#searchSuggestionsList button");
-    expect(button).not.toBeNull();
-    expect(button?.getAttribute("type")).toBe("button");
-    expect(button?.getAttribute("aria-label")).toContain("Room A");
+    const option = document.querySelector<HTMLElement>("#searchSuggestionsList [role='option']");
+    expect(option).not.toBeNull();
+    expect(option?.id).toBe("search-suggestion-0");
+    expect(option?.tabIndex).toBe(-1);
+    expect(option?.getAttribute("aria-selected")).toBe("false");
+    expect(option?.getAttribute("aria-label")).toContain("Room A");
   });
 
   it("does not render a category icon when none is configured", () => {
@@ -66,21 +83,113 @@ describe("SearchSuggestions", () => {
 
   it("calls onSelect and clears the list when a card is activated", () => {
     const onSelect = jest.fn();
-    SearchSuggestions.render(onSelect);
+    SearchSuggestions.render(input, onSelect);
     const s = suggestion();
     SearchSuggestions.update([s]);
 
-    const button = document.querySelector<HTMLButtonElement>("#searchSuggestionsList button")!;
-    button.click();
+    const option = document.querySelector<HTMLElement>("#searchSuggestionsList [role='option']")!;
+    option.click();
 
     expect(onSelect).toHaveBeenCalledWith(s);
     expect(document.getElementById("searchSuggestionsList")?.classList.contains("visible")).toBe(false);
-    expect(document.querySelectorAll("#searchSuggestionsList button")).toHaveLength(0);
+    expect(document.querySelectorAll("#searchSuggestionsList [role='option']")).toHaveLength(0);
   });
 
   it("clears the rendered list", () => {
+    SearchSuggestions.render(input, jest.fn());
     SearchSuggestions.update([suggestion()]);
     SearchSuggestions.clear();
-    expect(document.querySelectorAll("#searchSuggestionsList button")).toHaveLength(0);
+    expect(document.querySelectorAll("#searchSuggestionsList [role='option']")).toHaveLength(0);
+    expect(input.getAttribute("aria-expanded")).toBe("false");
+    expect(input.getAttribute("aria-activedescendant")).toBe("");
+  });
+
+  it("updates input combobox state when suggestions are shown", () => {
+    SearchSuggestions.render(input, jest.fn());
+    SearchSuggestions.update([suggestion()]);
+    expect(input.getAttribute("aria-expanded")).toBe("true");
+    expect(input.getAttribute("aria-activedescendant")).toBe("");
+  });
+
+  it("moves the active option with arrow keys", () => {
+    SearchSuggestions.render(input, jest.fn());
+    SearchSuggestions.update([
+      suggestion({ id: "way/1", displayName: "Room A" }),
+      suggestion({ id: "way/2", displayName: "Room B" }),
+    ]);
+
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown" }));
+    expect(input.getAttribute("aria-activedescendant")).toBe("search-suggestion-0");
+    expect(document.getElementById("search-suggestion-0")?.getAttribute("aria-selected")).toBe("true");
+
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown" }));
+    expect(input.getAttribute("aria-activedescendant")).toBe("search-suggestion-1");
+    expect(document.getElementById("search-suggestion-1")?.getAttribute("aria-selected")).toBe("true");
+  });
+
+  it("moves to the first option when either arrow key is pressed first", () => {
+    SearchSuggestions.render(input, jest.fn());
+    SearchSuggestions.update([
+      suggestion({ id: "way/1", displayName: "Room A" }),
+      suggestion({ id: "way/2", displayName: "Room B" }),
+    ]);
+
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowUp" }));
+    expect(input.getAttribute("aria-activedescendant")).toBe("search-suggestion-0");
+
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowUp" }));
+    expect(input.getAttribute("aria-activedescendant")).toBe("search-suggestion-1");
+  });
+
+  it("selects the active option with Enter", () => {
+    const onSelect = jest.fn();
+    const s = suggestion();
+    SearchSuggestions.render(input, onSelect);
+    SearchSuggestions.update([s]);
+
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown" }));
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
+
+    expect(onSelect).toHaveBeenCalledWith(s);
+    expect(input.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("hides suggestions with Escape without clearing the list", () => {
+    SearchSuggestions.render(input, jest.fn());
+    SearchSuggestions.update([suggestion()]);
+
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown" }));
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+
+    expect(document.querySelectorAll("#searchSuggestionsList [role='option']")).toHaveLength(1);
+    expect(document.getElementById("searchSuggestionsList")?.classList.contains("visible")).toBe(false);
+    expect(input.getAttribute("aria-expanded")).toBe("false");
+    expect(input.getAttribute("aria-activedescendant")).toBe("");
+    expect(document.getElementById("search-suggestion-0")?.getAttribute("aria-selected")).toBe("false");
+  });
+
+  it("reopens hidden suggestions and activates the first result with an arrow key", () => {
+    SearchSuggestions.render(input, jest.fn());
+    SearchSuggestions.update([
+      suggestion({ id: "way/1", displayName: "Room A" }),
+      suggestion({ id: "way/2", displayName: "Room B" }),
+    ]);
+
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowUp" }));
+
+    expect(document.getElementById("searchSuggestionsList")?.classList.contains("visible")).toBe(true);
+    expect(input.getAttribute("aria-expanded")).toBe("true");
+    expect(input.getAttribute("aria-activedescendant")).toBe("search-suggestion-0");
+  });
+
+  it("announces the number of available suggestions after a debounce", () => {
+    SearchSuggestions.update([suggestion(), suggestion({ id: "way/2", displayName: "Room B" })]);
+    expect(document.getElementById("searchAnnouncement")?.textContent).toBe("");
+
+    jest.advanceTimersByTime(250);
+
+    expect(document.getElementById("searchAnnouncement")?.textContent)
+      .toBe("2 search suggestions available.");
   });
 });

--- a/test/services/buildingServiceSearch.test.ts
+++ b/test/services/buildingServiceSearch.test.ts
@@ -1,0 +1,94 @@
+jest.mock("maptalks", () => ({}));
+jest.mock("../../src/services/backendService", () => ({
+  getGeoJson: jest.fn(),
+}));
+jest.mock("../../src/services/httpService", () => ({ default: {} }));
+jest.mock("../../src/services/languageService", () => ({
+  lang: { searchSuggestionLevel: "Level " },
+}));
+jest.mock("bbox-fns", () => ({ booleanContainsPoint: jest.fn() }));
+jest.mock("geojson-bounds", () => ({ extent: jest.fn() }));
+
+import BuildingService from "../../src/services/buildingService";
+import BackendService from "../../src/services/backendService";
+
+const mockFeatureWithName: GeoJSON.Feature = {
+  id: "way/1",
+  type: "Feature",
+  geometry: { type: "Polygon", coordinates: [] },
+  properties: { name: "Meeting Room", level: [1], indoor: "room" },
+};
+const mockFeatureWithRef: GeoJSON.Feature = {
+  id: "way/2",
+  type: "Feature",
+  geometry: { type: "Polygon", coordinates: [] },
+  properties: { ref: "B307", level: [0, 1], indoor: "room" },
+};
+const mockFeatureToilet: GeoJSON.Feature = {
+  id: "way/3",
+  type: "Feature",
+  geometry: { type: "Polygon", coordinates: [] },
+  properties: { amenity: "toilets", level: [2] },
+};
+
+describe("BuildingService.searchSuggestions", () => {
+  beforeEach(() => {
+    (BackendService.getGeoJson as jest.Mock).mockReturnValue({
+      type: "FeatureCollection",
+      features: [mockFeatureWithName, mockFeatureWithRef, mockFeatureToilet],
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns empty array for empty search string", () => {
+    expect(BuildingService.searchSuggestions("")).toEqual([]);
+  });
+
+  it("matches by name using substring (case-insensitive)", () => {
+    const results = BuildingService.searchSuggestions("meeting");
+    expect(results).toHaveLength(1);
+    expect(results[0].id).toBe("way/1");
+    expect(results[0].displayName).toBe("Meeting Room");
+    expect(results[0].levels).toEqual([1]);
+  });
+
+  it("uses name as displayName when present", () => {
+    const results = BuildingService.searchSuggestions("Meeting Room");
+    expect(results[0].displayName).toBe("Meeting Room");
+  });
+
+  it("matches by ref using startsWith (case-insensitive)", () => {
+    const results = BuildingService.searchSuggestions("B3");
+    expect(results).toHaveLength(1);
+    expect(results[0].id).toBe("way/2");
+  });
+
+  it("falls back displayName to ref when no name", () => {
+    const results = BuildingService.searchSuggestions("B307");
+    expect(results[0].displayName).toBe("B307");
+  });
+
+  it("returns multi-level array correctly", () => {
+    const results = BuildingService.searchSuggestions("B307");
+    expect(results[0].levels).toEqual([0, 1]);
+  });
+
+  it("matches by amenity using startsWith", () => {
+    const results = BuildingService.searchSuggestions("toilet");
+    expect(results).toHaveLength(1);
+    expect(results[0].id).toBe("way/3");
+  });
+
+  it("includes the original feature reference in suggestion", () => {
+    const results = BuildingService.searchSuggestions("meeting");
+    expect(results[0].feature).toBe(mockFeatureWithName);
+  });
+
+  it("returns empty array when no features match", () => {
+    const results = BuildingService.searchSuggestions("xyzzy");
+    expect(results).toHaveLength(0);
+  });
+});

--- a/test/services/buildingServiceSearch.test.ts
+++ b/test/services/buildingServiceSearch.test.ts
@@ -154,7 +154,7 @@ describe("BuildingService.searchSuggestions", () => {
     expect(BuildingService.searchSuggestions("lobby", CTX)).toHaveLength(0);
   });
 
-  it("excludes features with level as a non-normalized string (Point features)", () => {
+  it("parses string levels on point features", () => {
     const pointFeature: GeoJSON.Feature = {
       id: "way/8",
       type: "Feature",
@@ -165,7 +165,25 @@ describe("BuildingService.searchSuggestions", () => {
       type: "FeatureCollection",
       features: [pointFeature],
     });
-    expect(BuildingService.searchSuggestions("shower", CTX)).toHaveLength(0);
+    const results = BuildingService.searchSuggestions("shower", CTX);
+    expect(results).toHaveLength(1);
+    expect(results[0].levels).toEqual([0]);
+  });
+
+  it("includes repeat_on levels in suggestion levels", () => {
+    const repeatedFeature: GeoJSON.Feature = {
+      id: "way/9",
+      type: "Feature",
+      geometry: { type: "Polygon", coordinates: [] },
+      properties: { name: "Repeated Room", level: "0", repeat_on: "1-2" },
+    };
+    (BackendService.getGeoJson as jest.Mock).mockReturnValue({
+      type: "FeatureCollection",
+      features: [repeatedFeature],
+    });
+    const results = BuildingService.searchSuggestions("repeated", CTX);
+    expect(results).toHaveLength(1);
+    expect(results[0].levels).toEqual([0, 1, 2]);
   });
 
   it("returns empty array when no features match", () => {
@@ -216,6 +234,26 @@ describe("BuildingService.searchSuggestions", () => {
       const results = BuildingService.searchSuggestions("room", { currentLevel: 0 });
       expect(results[0].id).toBe("way/21");
       expect(results[1].id).toBe("way/20");
+    });
+
+    it("uses repeat_on levels when ranking by level distance", () => {
+      const repeatedOn2: GeoJSON.Feature = {
+        id: "way/22", type: "Feature",
+        geometry: { type: "Polygon", coordinates: [] },
+        properties: { name: "room repeated", level: "0", repeat_on: "2" },
+      };
+      const level0: GeoJSON.Feature = {
+        id: "way/23", type: "Feature",
+        geometry: { type: "Polygon", coordinates: [] },
+        properties: { name: "room base", level: [0] },
+      };
+      (BackendService.getGeoJson as jest.Mock).mockReturnValue({
+        type: "FeatureCollection",
+        features: [level0, repeatedOn2],
+      });
+      const results = BuildingService.searchSuggestions("room", { currentLevel: 2 });
+      expect(results[0].id).toBe("way/22");
+      expect(results[1].id).toBe("way/23");
     });
 
     it("ranks closer to selected feature before farther when match and level are equal", () => {

--- a/test/services/buildingServiceSearch.test.ts
+++ b/test/services/buildingServiceSearch.test.ts
@@ -409,4 +409,83 @@ describe("BuildingService.searchSuggestions", () => {
       expect(results[1].id).toBe("way/40");
     });
   });
+
+  it("logs sorted ranking details when search suggestion debug mode is enabled", () => {
+    const originalLocalStorage = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+    const debugSpy = jest.spyOn(console, "debug").mockImplementation();
+    const tableSpy = jest.spyOn(console, "table").mockImplementation();
+
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: {
+        getItem: jest.fn((key: string) => key === "debugSearchSuggestions" ? "true" : null),
+      },
+    });
+
+    const near: GeoJSON.Feature = {
+      id: "way/70", type: "Feature",
+      geometry: { type: "Polygon", coordinates: [[[0, 0], [0.01, 0], [0.01, 0.01], [0, 0.01], [0, 0]]] },
+      properties: { name: "room debug near", level: [0] },
+    };
+    const far: GeoJSON.Feature = {
+      id: "way/71", type: "Feature",
+      geometry: { type: "Polygon", coordinates: [[[1, 1], [1.01, 1], [1.01, 1.01], [1, 1.01], [1, 1]]] },
+      properties: { name: "room debug far", level: [1], wheelchair: "yes" },
+    };
+    const selected: GeoJSON.Feature = {
+      id: "way/72", type: "Feature",
+      geometry: { type: "Polygon", coordinates: [[[0, 0], [0.01, 0], [0.01, 0.01], [0, 0.01], [0, 0]]] },
+      properties: { level: [0] },
+    };
+    (BackendService.getGeoJson as jest.Mock).mockReturnValue({
+      type: "FeatureCollection",
+      features: [far, near],
+    });
+
+    try {
+      BuildingService.searchSuggestions("room", {
+        currentLevel: 0,
+        selectedFeature: selected,
+        infoPointFeature: selected,
+        wheelchairMode: true,
+      });
+
+      expect(debugSpy).toHaveBeenCalledWith("[SearchSuggestions] ranking context", expect.objectContaining({
+        query: "room",
+        sortOrder: [
+          "matchScore",
+          "wheelchairScore",
+          "levelDistance",
+          "selectedDistanceSq",
+          "infoDistanceSq",
+        ],
+      }));
+      expect(tableSpy).toHaveBeenCalledWith([
+        expect.objectContaining({
+          rank: 1,
+          id: "way/71",
+          matchScore: 1,
+          wheelchairScore: 0,
+          wheelchairAccessible: true,
+          levelDistance: 1,
+        }),
+        expect.objectContaining({
+          rank: 2,
+          id: "way/70",
+          matchScore: 1,
+          wheelchairScore: 1,
+          wheelchairAccessible: false,
+          levelDistance: 0,
+        }),
+      ]);
+    } finally {
+      debugSpy.mockRestore();
+      tableSpy.mockRestore();
+      if (originalLocalStorage) {
+        Object.defineProperty(globalThis, "localStorage", originalLocalStorage);
+      } else {
+        delete (globalThis as { localStorage?: Storage }).localStorage;
+      }
+    }
+  });
 });

--- a/test/services/buildingServiceSearch.test.ts
+++ b/test/services/buildingServiceSearch.test.ts
@@ -118,7 +118,7 @@ describe("BuildingService.searchSuggestions", () => {
     expect(results[0].feature).toBe(mockFeatureWithName);
   });
 
-  it("ignores name=yes (OSM artifact) and does not match or display it", () => {
+  it("ignores name=yes (OSM artifact) and excludes waste_basket amenity", () => {
     const artifactFeature: GeoJSON.Feature = {
       id: "way/6",
       type: "Feature",
@@ -130,8 +130,7 @@ describe("BuildingService.searchSuggestions", () => {
       features: [artifactFeature],
     });
     expect(BuildingService.searchSuggestions("yes")).toHaveLength(0);
-    expect(BuildingService.searchSuggestions("waste")).toHaveLength(1);
-    expect(BuildingService.searchSuggestions("waste")[0].displayName).toBe("waste_basket");
+    expect(BuildingService.searchSuggestions("waste")).toHaveLength(0);
   });
 
   it("does not match features by indoor type alone", () => {

--- a/test/services/buildingServiceSearch.test.ts
+++ b/test/services/buildingServiceSearch.test.ts
@@ -88,6 +88,31 @@ describe("BuildingService.searchSuggestions", () => {
     expect(results[0].id).toBe("way/3");
   });
 
+  it("sets type from amenity when present", () => {
+    const results = BuildingService.searchSuggestions("toilet");
+    expect(results[0].type).toBe("toilets");
+  });
+
+  it("sets type from indoor when no amenity", () => {
+    const results = BuildingService.searchSuggestions("B307");
+    expect(results[0].type).toBe("room");
+  });
+
+  it("type is undefined when neither amenity nor indoor is set", () => {
+    const noTypeFeature: GeoJSON.Feature = {
+      id: "way/5",
+      type: "Feature",
+      geometry: { type: "Polygon", coordinates: [] },
+      properties: { name: "Mystery Space", level: [0] },
+    };
+    (BackendService.getGeoJson as jest.Mock).mockReturnValue({
+      type: "FeatureCollection",
+      features: [noTypeFeature],
+    });
+    const results = BuildingService.searchSuggestions("mystery");
+    expect(results[0].type).toBeUndefined();
+  });
+
   it("includes the original feature reference in suggestion", () => {
     const results = BuildingService.searchSuggestions("meeting");
     expect(results[0].feature).toBe(mockFeatureWithName);

--- a/test/services/buildingServiceSearch.test.ts
+++ b/test/services/buildingServiceSearch.test.ts
@@ -12,6 +12,8 @@ jest.mock("geojson-bounds", () => ({ extent: jest.fn() }));
 import BuildingService from "../../src/services/buildingService";
 import BackendService from "../../src/services/backendService";
 
+const CTX = { currentLevel: 0 };
+
 const mockFeatureWithName: GeoJSON.Feature = {
   id: "way/1",
   type: "Feature",
@@ -50,11 +52,11 @@ describe("BuildingService.searchSuggestions", () => {
   });
 
   it("returns empty array for empty search string", () => {
-    expect(BuildingService.searchSuggestions("")).toEqual([]);
+    expect(BuildingService.searchSuggestions("", CTX)).toEqual([]);
   });
 
   it("matches by name using substring (case-insensitive)", () => {
-    const results = BuildingService.searchSuggestions("meeting");
+    const results = BuildingService.searchSuggestions("meeting", CTX);
     expect(results).toHaveLength(1);
     expect(results[0].id).toBe("way/1");
     expect(results[0].displayName).toBe("Meeting Room");
@@ -62,39 +64,39 @@ describe("BuildingService.searchSuggestions", () => {
   });
 
   it("uses name as displayName when present", () => {
-    const results = BuildingService.searchSuggestions("Meeting Room");
+    const results = BuildingService.searchSuggestions("Meeting Room", CTX);
     expect(results[0].displayName).toBe("Meeting Room");
   });
 
   it("matches by ref using startsWith (case-insensitive)", () => {
-    const results = BuildingService.searchSuggestions("B3");
+    const results = BuildingService.searchSuggestions("B3", CTX);
     expect(results).toHaveLength(1);
     expect(results[0].id).toBe("way/2");
   });
 
   it("falls back displayName to ref when no name", () => {
-    const results = BuildingService.searchSuggestions("B307");
+    const results = BuildingService.searchSuggestions("B307", CTX);
     expect(results[0].displayName).toBe("B307");
   });
 
   it("returns multi-level array correctly", () => {
-    const results = BuildingService.searchSuggestions("B307");
+    const results = BuildingService.searchSuggestions("B307", CTX);
     expect(results[0].levels).toEqual([0, 1]);
   });
 
   it("matches by amenity using startsWith", () => {
-    const results = BuildingService.searchSuggestions("toilet");
+    const results = BuildingService.searchSuggestions("toilet", CTX);
     expect(results).toHaveLength(1);
     expect(results[0].id).toBe("way/3");
   });
 
   it("sets type from amenity when present", () => {
-    const results = BuildingService.searchSuggestions("toilet");
+    const results = BuildingService.searchSuggestions("toilet", CTX);
     expect(results[0].type).toBe("toilets");
   });
 
   it("sets type from indoor when no amenity", () => {
-    const results = BuildingService.searchSuggestions("B307");
+    const results = BuildingService.searchSuggestions("B307", CTX);
     expect(results[0].type).toBe("room");
   });
 
@@ -109,12 +111,12 @@ describe("BuildingService.searchSuggestions", () => {
       type: "FeatureCollection",
       features: [noTypeFeature],
     });
-    const results = BuildingService.searchSuggestions("mystery");
+    const results = BuildingService.searchSuggestions("mystery", CTX);
     expect(results[0].type).toBeUndefined();
   });
 
   it("includes the original feature reference in suggestion", () => {
-    const results = BuildingService.searchSuggestions("meeting");
+    const results = BuildingService.searchSuggestions("meeting", CTX);
     expect(results[0].feature).toBe(mockFeatureWithName);
   });
 
@@ -129,12 +131,12 @@ describe("BuildingService.searchSuggestions", () => {
       type: "FeatureCollection",
       features: [artifactFeature],
     });
-    expect(BuildingService.searchSuggestions("yes")).toHaveLength(0);
-    expect(BuildingService.searchSuggestions("waste")).toHaveLength(0);
+    expect(BuildingService.searchSuggestions("yes", CTX)).toHaveLength(0);
+    expect(BuildingService.searchSuggestions("waste", CTX)).toHaveLength(0);
   });
 
   it("does not match features by indoor type alone", () => {
-    const results = BuildingService.searchSuggestions("pathway");
+    const results = BuildingService.searchSuggestions("pathway", CTX);
     expect(results).toHaveLength(0);
   });
 
@@ -149,7 +151,7 @@ describe("BuildingService.searchSuggestions", () => {
       type: "FeatureCollection",
       features: [noLevelFeature],
     });
-    expect(BuildingService.searchSuggestions("lobby")).toHaveLength(0);
+    expect(BuildingService.searchSuggestions("lobby", CTX)).toHaveLength(0);
   });
 
   it("excludes features with level as a non-normalized string (Point features)", () => {
@@ -163,11 +165,57 @@ describe("BuildingService.searchSuggestions", () => {
       type: "FeatureCollection",
       features: [pointFeature],
     });
-    expect(BuildingService.searchSuggestions("shower")).toHaveLength(0);
+    expect(BuildingService.searchSuggestions("shower", CTX)).toHaveLength(0);
   });
 
   it("returns empty array when no features match", () => {
-    const results = BuildingService.searchSuggestions("xyzzy");
+    const results = BuildingService.searchSuggestions("xyzzy", CTX);
     expect(results).toHaveLength(0);
+  });
+
+  describe("sort order", () => {
+    it("ranks exact displayName match before startsWith before substring", () => {
+      const exact: GeoJSON.Feature = {
+        id: "way/10", type: "Feature",
+        geometry: { type: "Polygon", coordinates: [] },
+        properties: { name: "room", level: [0] },
+      };
+      const starts: GeoJSON.Feature = {
+        id: "way/11", type: "Feature",
+        geometry: { type: "Polygon", coordinates: [] },
+        properties: { name: "room 101", level: [0] },
+      };
+      const contains: GeoJSON.Feature = {
+        id: "way/12", type: "Feature",
+        geometry: { type: "Polygon", coordinates: [] },
+        properties: { name: "east room", level: [0] },
+      };
+      (BackendService.getGeoJson as jest.Mock).mockReturnValue({
+        type: "FeatureCollection",
+        features: [contains, starts, exact],
+      });
+      const results = BuildingService.searchSuggestions("room", CTX);
+      expect(results.map((r) => r.id)).toEqual(["way/10", "way/11", "way/12"]);
+    });
+
+    it("uses level proximity as tiebreaker when match score is equal", () => {
+      const level2: GeoJSON.Feature = {
+        id: "way/20", type: "Feature",
+        geometry: { type: "Polygon", coordinates: [] },
+        properties: { name: "room A", level: [2] },
+      };
+      const level0: GeoJSON.Feature = {
+        id: "way/21", type: "Feature",
+        geometry: { type: "Polygon", coordinates: [] },
+        properties: { name: "room B", level: [0] },
+      };
+      (BackendService.getGeoJson as jest.Mock).mockReturnValue({
+        type: "FeatureCollection",
+        features: [level2, level0],
+      });
+      const results = BuildingService.searchSuggestions("room", { currentLevel: 0 });
+      expect(results[0].id).toBe("way/21");
+      expect(results[1].id).toBe("way/20");
+    });
   });
 });

--- a/test/services/buildingServiceSearch.test.ts
+++ b/test/services/buildingServiceSearch.test.ts
@@ -118,6 +118,22 @@ describe("BuildingService.searchSuggestions", () => {
     expect(results[0].feature).toBe(mockFeatureWithName);
   });
 
+  it("ignores name=yes (OSM artifact) and does not match or display it", () => {
+    const artifactFeature: GeoJSON.Feature = {
+      id: "way/6",
+      type: "Feature",
+      geometry: { type: "Point", coordinates: [] },
+      properties: { name: "yes", amenity: "waste_basket", level: [1] },
+    };
+    (BackendService.getGeoJson as jest.Mock).mockReturnValue({
+      type: "FeatureCollection",
+      features: [artifactFeature],
+    });
+    expect(BuildingService.searchSuggestions("yes")).toHaveLength(0);
+    expect(BuildingService.searchSuggestions("waste")).toHaveLength(1);
+    expect(BuildingService.searchSuggestions("waste")[0].displayName).toBe("waste_basket");
+  });
+
   it("does not match features by indoor type alone", () => {
     const results = BuildingService.searchSuggestions("pathway");
     expect(results).toHaveLength(0);

--- a/test/services/buildingServiceSearch.test.ts
+++ b/test/services/buildingServiceSearch.test.ts
@@ -284,6 +284,34 @@ describe("BuildingService.searchSuggestions", () => {
       expect(results[1].id).toBe("way/31");
     });
 
+    it("ranks closer to info point before farther when match, level, and selected feature are equal", () => {
+      const near: GeoJSON.Feature = {
+        id: "way/60", type: "Feature",
+        geometry: { type: "Polygon", coordinates: [[[0, 0], [0.01, 0], [0.01, 0.01], [0, 0.01], [0, 0]]] },
+        properties: { name: "room E", level: [0] },
+      };
+      const far: GeoJSON.Feature = {
+        id: "way/61", type: "Feature",
+        geometry: { type: "Polygon", coordinates: [[[1, 1], [1.01, 1], [1.01, 1.01], [1, 1.01], [1, 1]]] },
+        properties: { name: "room F", level: [0] },
+      };
+      const infoPoint: GeoJSON.Feature = {
+        id: "way/98", type: "Feature",
+        geometry: { type: "Polygon", coordinates: [[[0, 0], [0.01, 0], [0.01, 0.01], [0, 0.01], [0, 0]]] },
+        properties: { level: [0] },
+      };
+      (BackendService.getGeoJson as jest.Mock).mockReturnValue({
+        type: "FeatureCollection",
+        features: [far, near],
+      });
+      const results = BuildingService.searchSuggestions("room", {
+        currentLevel: 0,
+        infoPointFeature: infoPoint,
+      });
+      expect(results[0].id).toBe("way/60");
+      expect(results[1].id).toBe("way/61");
+    });
+
     it("ranks a higher-priority field before a lower-priority field at equal match quality", () => {
       const refPrefixMatch: GeoJSON.Feature = {
         id: "way/50", type: "Feature",

--- a/test/services/buildingServiceSearch.test.ts
+++ b/test/services/buildingServiceSearch.test.ts
@@ -312,6 +312,34 @@ describe("BuildingService.searchSuggestions", () => {
       expect(results[1].id).toBe("way/61");
     });
 
+    it("uses point info features when ranking by proximity", () => {
+      const near: GeoJSON.Feature = {
+        id: "way/62", type: "Feature",
+        geometry: { type: "Polygon", coordinates: [[[0, 0], [0.01, 0], [0.01, 0.01], [0, 0.01], [0, 0]]] },
+        properties: { name: "room G", level: [0] },
+      };
+      const far: GeoJSON.Feature = {
+        id: "way/63", type: "Feature",
+        geometry: { type: "Polygon", coordinates: [[[1, 1], [1.01, 1], [1.01, 1.01], [1, 1.01], [1, 1]]] },
+        properties: { name: "room H", level: [0] },
+      };
+      const infoPoint: GeoJSON.Feature = {
+        id: "node/98", type: "Feature",
+        geometry: { type: "Point", coordinates: [0, 0] },
+        properties: { level: [0] },
+      };
+      (BackendService.getGeoJson as jest.Mock).mockReturnValue({
+        type: "FeatureCollection",
+        features: [far, near],
+      });
+      const results = BuildingService.searchSuggestions("room", {
+        currentLevel: 0,
+        infoPointFeature: infoPoint,
+      });
+      expect(results[0].id).toBe("way/62");
+      expect(results[1].id).toBe("way/63");
+    });
+
     it("ranks a higher-priority field before a lower-priority field at equal match quality", () => {
       const refPrefixMatch: GeoJSON.Feature = {
         id: "way/50", type: "Feature",

--- a/test/services/buildingServiceSearch.test.ts
+++ b/test/services/buildingServiceSearch.test.ts
@@ -198,7 +198,7 @@ describe("BuildingService.searchSuggestions", () => {
       expect(results.map((r) => r.id)).toEqual(["way/10", "way/11", "way/12"]);
     });
 
-    it("uses level proximity as tiebreaker when match score is equal", () => {
+    it("ranks closer level before farther level when match score is equal", () => {
       const level2: GeoJSON.Feature = {
         id: "way/20", type: "Feature",
         geometry: { type: "Polygon", coordinates: [] },
@@ -216,6 +216,34 @@ describe("BuildingService.searchSuggestions", () => {
       const results = BuildingService.searchSuggestions("room", { currentLevel: 0 });
       expect(results[0].id).toBe("way/21");
       expect(results[1].id).toBe("way/20");
+    });
+
+    it("ranks closer to selected feature before farther when match and level are equal", () => {
+      const near: GeoJSON.Feature = {
+        id: "way/30", type: "Feature",
+        geometry: { type: "Polygon", coordinates: [[[0, 0], [0.01, 0], [0.01, 0.01], [0, 0.01], [0, 0]]] },
+        properties: { name: "room C", level: [0] },
+      };
+      const far: GeoJSON.Feature = {
+        id: "way/31", type: "Feature",
+        geometry: { type: "Polygon", coordinates: [[[1, 1], [1.01, 1], [1.01, 1.01], [1, 1.01], [1, 1]]] },
+        properties: { name: "room D", level: [0] },
+      };
+      const selected: GeoJSON.Feature = {
+        id: "way/99", type: "Feature",
+        geometry: { type: "Polygon", coordinates: [[[0, 0], [0.01, 0], [0.01, 0.01], [0, 0.01], [0, 0]]] },
+        properties: { level: [0] },
+      };
+      (BackendService.getGeoJson as jest.Mock).mockReturnValue({
+        type: "FeatureCollection",
+        features: [far, near],
+      });
+      const results = BuildingService.searchSuggestions("room", {
+        currentLevel: 0,
+        selectedFeature: selected,
+      });
+      expect(results[0].id).toBe("way/30");
+      expect(results[1].id).toBe("way/31");
     });
   });
 });

--- a/test/services/buildingServiceSearch.test.ts
+++ b/test/services/buildingServiceSearch.test.ts
@@ -138,7 +138,7 @@ describe("BuildingService.searchSuggestions", () => {
     expect(results).toHaveLength(0);
   });
 
-  it("excludes features with no level", () => {
+  it("excludes features with no level property", () => {
     const noLevelFeature: GeoJSON.Feature = {
       id: "way/7",
       type: "Feature",
@@ -150,7 +150,20 @@ describe("BuildingService.searchSuggestions", () => {
       features: [noLevelFeature],
     });
     expect(BuildingService.searchSuggestions("lobby")).toHaveLength(0);
-    expect(BuildingService.searchSuggestions("L1")).toHaveLength(0);
+  });
+
+  it("excludes features with level as a non-normalized string (Point features)", () => {
+    const pointFeature: GeoJSON.Feature = {
+      id: "way/8",
+      type: "Feature",
+      geometry: { type: "Point", coordinates: [] },
+      properties: { name: "Shower", amenity: "shower", level: "0" },
+    };
+    (BackendService.getGeoJson as jest.Mock).mockReturnValue({
+      type: "FeatureCollection",
+      features: [pointFeature],
+    });
+    expect(BuildingService.searchSuggestions("shower")).toHaveLength(0);
   });
 
   it("returns empty array when no features match", () => {

--- a/test/services/buildingServiceSearch.test.ts
+++ b/test/services/buildingServiceSearch.test.ts
@@ -138,6 +138,21 @@ describe("BuildingService.searchSuggestions", () => {
     expect(results).toHaveLength(0);
   });
 
+  it("excludes features with no level", () => {
+    const noLevelFeature: GeoJSON.Feature = {
+      id: "way/7",
+      type: "Feature",
+      geometry: { type: "Polygon", coordinates: [] },
+      properties: { name: "Lobby", ref: "L1" },
+    };
+    (BackendService.getGeoJson as jest.Mock).mockReturnValue({
+      type: "FeatureCollection",
+      features: [noLevelFeature],
+    });
+    expect(BuildingService.searchSuggestions("lobby")).toHaveLength(0);
+    expect(BuildingService.searchSuggestions("L1")).toHaveLength(0);
+  });
+
   it("returns empty array when no features match", () => {
     const results = BuildingService.searchSuggestions("xyzzy");
     expect(results).toHaveLength(0);

--- a/test/services/buildingServiceSearch.test.ts
+++ b/test/services/buildingServiceSearch.test.ts
@@ -283,5 +283,45 @@ describe("BuildingService.searchSuggestions", () => {
       expect(results[0].id).toBe("way/30");
       expect(results[1].id).toBe("way/31");
     });
+
+    it("ranks a higher-priority field before a lower-priority field at equal match quality", () => {
+      const refPrefixMatch: GeoJSON.Feature = {
+        id: "way/50", type: "Feature",
+        geometry: { type: "Polygon", coordinates: [] },
+        properties: { ref: "toiletA", level: [0] },
+      };
+      const amenityPrefixMatch: GeoJSON.Feature = {
+        id: "way/51", type: "Feature",
+        geometry: { type: "Polygon", coordinates: [] },
+        properties: { amenity: "toilets", level: [0] },
+      };
+      (BackendService.getGeoJson as jest.Mock).mockReturnValue({
+        type: "FeatureCollection",
+        features: [amenityPrefixMatch, refPrefixMatch],
+      });
+      const results = BuildingService.searchSuggestions("toilet", CTX);
+      expect(results.map((r) => r.id)).toEqual(["way/50", "way/51"]);
+    });
+
+    it("scores a feature by its best-matching field, not just its displayName", () => {
+      const exactRefWithName: GeoJSON.Feature = {
+        id: "way/52", type: "Feature",
+        geometry: { type: "Polygon", coordinates: [] },
+        properties: { name: "Lecture Hall", ref: "z12", level: [0] },
+      };
+      const substringNameMatch: GeoJSON.Feature = {
+        id: "way/53", type: "Feature",
+        geometry: { type: "Polygon", coordinates: [] },
+        properties: { name: "Room Z12 Wing", level: [0] },
+      };
+      (BackendService.getGeoJson as jest.Mock).mockReturnValue({
+        type: "FeatureCollection",
+        features: [exactRefWithName, substringNameMatch],
+      });
+      const results = BuildingService.searchSuggestions("z12", CTX);
+      // an exact ref match ranks close behind (not unpredictably below) a substring
+      // name match, even though this feature also has an unrelated name property
+      expect(results.map((r) => r.id)).toEqual(["way/53", "way/52"]);
+    });
   });
 });

--- a/test/services/buildingServiceSearch.test.ts
+++ b/test/services/buildingServiceSearch.test.ts
@@ -30,12 +30,18 @@ const mockFeatureToilet: GeoJSON.Feature = {
   geometry: { type: "Polygon", coordinates: [] },
   properties: { amenity: "toilets", level: [2] },
 };
+const mockFeaturePathway: GeoJSON.Feature = {
+  id: "way/4",
+  type: "Feature",
+  geometry: { type: "LineString", coordinates: [] },
+  properties: { indoor: "pathway", level: [1] },
+};
 
 describe("BuildingService.searchSuggestions", () => {
   beforeEach(() => {
     (BackendService.getGeoJson as jest.Mock).mockReturnValue({
       type: "FeatureCollection",
-      features: [mockFeatureWithName, mockFeatureWithRef, mockFeatureToilet],
+      features: [mockFeatureWithName, mockFeatureWithRef, mockFeatureToilet, mockFeaturePathway],
     });
   });
 
@@ -85,6 +91,11 @@ describe("BuildingService.searchSuggestions", () => {
   it("includes the original feature reference in suggestion", () => {
     const results = BuildingService.searchSuggestions("meeting");
     expect(results[0].feature).toBe(mockFeatureWithName);
+  });
+
+  it("does not match features by indoor type alone", () => {
+    const results = BuildingService.searchSuggestions("pathway");
+    expect(results).toHaveLength(0);
   });
 
   it("returns empty array when no features match", () => {

--- a/test/services/buildingServiceSearch.test.ts
+++ b/test/services/buildingServiceSearch.test.ts
@@ -351,5 +351,62 @@ describe("BuildingService.searchSuggestions", () => {
       // name match, even though this feature also has an unrelated name property
       expect(results.map((r) => r.id)).toEqual(["way/53", "way/52"]);
     });
+
+    it("ranks wheelchair-accessible rooms first in wheelchair mode, even if farther away", () => {
+      const accessibleFar: GeoJSON.Feature = {
+        id: "way/40", type: "Feature",
+        geometry: { type: "Polygon", coordinates: [[[5, 5], [5.01, 5], [5.01, 5.01], [5, 5.01], [5, 5]]] },
+        properties: { amenity: "toilets", wheelchair: "yes", level: [0] },
+      };
+      const nearNonAccessible: GeoJSON.Feature = {
+        id: "way/41", type: "Feature",
+        geometry: { type: "Polygon", coordinates: [[[0, 0], [0.01, 0], [0.01, 0.01], [0, 0.01], [0, 0]]] },
+        properties: { amenity: "toilets", level: [0] },
+      };
+      const selected: GeoJSON.Feature = {
+        id: "way/99", type: "Feature",
+        geometry: { type: "Polygon", coordinates: [[[0, 0], [0.01, 0], [0.01, 0.01], [0, 0.01], [0, 0]]] },
+        properties: { level: [0] },
+      };
+      (BackendService.getGeoJson as jest.Mock).mockReturnValue({
+        type: "FeatureCollection",
+        features: [nearNonAccessible, accessibleFar],
+      });
+      const results = BuildingService.searchSuggestions("toilet", {
+        currentLevel: 0,
+        selectedFeature: selected,
+        wheelchairMode: true,
+      });
+      expect(results[0].id).toBe("way/40");
+      expect(results[1].id).toBe("way/41");
+    });
+
+    it("ranks the closer room first when wheelchair mode is off", () => {
+      const accessibleFar: GeoJSON.Feature = {
+        id: "way/40", type: "Feature",
+        geometry: { type: "Polygon", coordinates: [[[5, 5], [5.01, 5], [5.01, 5.01], [5, 5.01], [5, 5]]] },
+        properties: { amenity: "toilets", wheelchair: "yes", level: [0] },
+      };
+      const nearNonAccessible: GeoJSON.Feature = {
+        id: "way/41", type: "Feature",
+        geometry: { type: "Polygon", coordinates: [[[0, 0], [0.01, 0], [0.01, 0.01], [0, 0.01], [0, 0]]] },
+        properties: { amenity: "toilets", level: [0] },
+      };
+      const selected: GeoJSON.Feature = {
+        id: "way/99", type: "Feature",
+        geometry: { type: "Polygon", coordinates: [[[0, 0], [0.01, 0], [0.01, 0.01], [0, 0.01], [0, 0]]] },
+        properties: { level: [0] },
+      };
+      (BackendService.getGeoJson as jest.Mock).mockReturnValue({
+        type: "FeatureCollection",
+        features: [accessibleFar, nearNonAccessible],
+      });
+      const results = BuildingService.searchSuggestions("toilet", {
+        currentLevel: 0,
+        selectedFeature: selected,
+      });
+      expect(results[0].id).toBe("way/41");
+      expect(results[1].id).toBe("way/40");
+    });
   });
 });

--- a/test/services/featureService.test.ts
+++ b/test/services/featureService.test.ts
@@ -1,0 +1,56 @@
+/**
+ * @jest-environment jsdom
+ */
+import { getCategoryIcon } from "../../src/services/featureService";
+import { MARKERS_IMG_DIR, ICONS } from "../../public/strings/constants.json";
+
+function feature(properties: Record<string, unknown>): GeoJSON.Feature {
+  return {
+    id: "way/1",
+    type: "Feature",
+    geometry: { type: "Polygon", coordinates: [] },
+    properties,
+  };
+}
+
+describe("getCategoryIcon", () => {
+  it("returns the wheelchair-accessible toilet icon for accessible toilets", () => {
+    expect(getCategoryIcon(feature({ amenity: "toilets", wheelchair: "yes" })))
+      .toBe(MARKERS_IMG_DIR + ICONS.TOILETS_WHEELCHAIR);
+  });
+
+  it("returns the toilet icon for non-accessible toilets", () => {
+    expect(getCategoryIcon(feature({ amenity: "toilets" })))
+      .toBe(MARKERS_IMG_DIR + ICONS.TOILETS);
+  });
+
+  it("returns the cafe icon for cafes", () => {
+    expect(getCategoryIcon(feature({ amenity: "cafe" })))
+      .toBe(MARKERS_IMG_DIR + ICONS.CAFE);
+  });
+
+  it("returns the shop icon for shops", () => {
+    expect(getCategoryIcon(feature({ shop: "convenience" })))
+      .toBe(MARKERS_IMG_DIR + ICONS.SHOP);
+  });
+
+  it("returns the elevator icon for elevators", () => {
+    expect(getCategoryIcon(feature({ highway: "elevator" })))
+      .toBe(MARKERS_IMG_DIR + ICONS.ELEVATOR);
+  });
+
+  it("returns the stairs icon for stairs", () => {
+    expect(getCategoryIcon(feature({ stairs: "yes" })))
+      .toBe(MARKERS_IMG_DIR + ICONS.STAIRS);
+  });
+
+  it("returns the entrance icon for entrances", () => {
+    expect(getCategoryIcon(feature({ entrance: "main" })))
+      .toBe(MARKERS_IMG_DIR + ICONS.ENTRANCE);
+  });
+
+  it("falls back to the generic icon for unrecognized rooms", () => {
+    expect(getCategoryIcon(feature({ indoor: "room" })))
+      .toBe(MARKERS_IMG_DIR + ICONS.ADDITIONAL);
+  });
+});

--- a/test/services/featureService.test.ts
+++ b/test/services/featureService.test.ts
@@ -49,8 +49,8 @@ describe("getCategoryIcon", () => {
       .toBe(MARKERS_IMG_DIR + ICONS.ENTRANCE);
   });
 
-  it("falls back to the generic icon for unrecognized rooms", () => {
+  it("returns no icon for unrecognized rooms", () => {
     expect(getCategoryIcon(feature({ indoor: "room" })))
-      .toBe(MARKERS_IMG_DIR + ICONS.ADDITIONAL);
+      .toBeUndefined();
   });
 });

--- a/test/utils/compareChain.test.ts
+++ b/test/utils/compareChain.test.ts
@@ -1,0 +1,28 @@
+import { chainComparators } from "../../src/utils/compareChain";
+
+describe("chainComparators", () => {
+  it("returns 0 when given no comparators", () => {
+    expect(chainComparators<number>()(1, 2)).toBe(0);
+  });
+
+  it("uses the first comparator that returns a non-zero result", () => {
+    const alwaysEqual = () => 0;
+    const bBeforeA = () => 1;
+    const aBeforeB = () => -1;
+
+    const combined = chainComparators(alwaysEqual, bBeforeA, aBeforeB);
+    expect(combined(1, 2)).toBe(1);
+  });
+
+  it("falls back to 0 when all comparators tie", () => {
+    const combined = chainComparators<number>(() => 0, () => 0);
+    expect(combined(1, 2)).toBe(0);
+  });
+
+  it("can sort an array using the combined comparator", () => {
+    const byEvenFirst = (a: number, b: number) => Number(a % 2 !== 0) - Number(b % 2 !== 0);
+    const byValue = (a: number, b: number) => a - b;
+    const sorted = [5, 4, 3, 2, 1].sort(chainComparators(byEvenFirst, byValue));
+    expect(sorted).toEqual([2, 4, 1, 3, 5]);
+  });
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -2,7 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "CommonJS",
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "ignoreDeprecations": "6.0"
   },
   "include": ["src", "test"]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -2,8 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "CommonJS",
-    "moduleResolution": "node",
-    "ignoreDeprecations": "6.0"
+    "moduleResolution": "node"
   },
   "include": ["src", "test"]
 }


### PR DESCRIPTION
## Summary
Reworks the indoor search experience around a live, sorted suggestion list instead of a single "search and jump" action.

### Added
- Live search suggestion cards with category icons, room-type labels, and keyboard-accessible buttons/ARIA combobox pattern.
- Clear buttons for search input and errors, plus a suggestion sort-order debug view.
- Multi-key suggestion sorting (per-field match score, level, wheelchair accessibility, selection/infopoint proximity) via a reusable comparator-chain utility.

### Changed
- Enter/Search now routes through the sorted suggestion list instead of the old `handleIndoorSearch`/`runIndoorSearch` path.
- Search errors now surface inline above the search bar instead of as a top-left toast.

### Fixed
- Suggestions now filter out features without a level, indoor-type features, waste baskets, and OSM name artifacts (e.g. "yes"/"no").

See `CHANGELOG.md` (`Unreleased`) for the full list.